### PR TITLE
修正 Extension: JP_..._InstructionForDispense

### DIFF
--- a/input/fsh/profiles/JP_MedicationRequestBase.fsh
+++ b/input/fsh/profiles/JP_MedicationRequestBase.fsh
@@ -918,7 +918,7 @@ Description: "調剤指示。薬剤単位の調剤指示を表現するための
 * ^context.expression = "MedicationRequest.dispenseRequest"
 * id ..0
 * url = "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DispenseRequest_InstructionForDispense" (exactly)
-* value[x] only string or CodeableConcept
+* value[x] only CodeableConcept
 
 Extension: JP_MedicationRequest_DosageInstruction_Device
 Id: jp-medicationrequest-dosageinstruction-device


### PR DESCRIPTION
## 修正内容
* value[x] only string or CodeableConcept
を
* value[x] only  CodeableConcept
に修正。
CodeableConcept.text に文字列だけを記述することが可能であるため、あえてstring型を選択できるようにしておく必要がない。
なるべくシンプルなほうがよいため。

## 担当SWG
<!-- (SWG[1-6] もしくは アカウント名) -->
SWG5

## Merge依頼先
<!-- (SGW[1-6] もしくは アカウント名) -->
<!-- 個人を指定するにはあわせてReviewersに設定すること-->
SWG5

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->

## 補足

