### PR TITLE
漢字名、カナ名による検索型がtokenとなっていましたが、オリジナルの検索型と同じstringとしました。

### DIFF
--- a/input/fsh/searchparameters/JP_Patient_SP.fsh
+++ b/input/fsh/searchparameters/JP_Patient_SP.fsh
@@ -8,7 +8,7 @@ Usage: #definition
 * description = "PatientリソースのKanjiName(漢字名称)に関する検索を定義します。"
 * code = #jp-kanji-name
 * base = #Patient
-* type = #token
+* type = #string
 * expression = "Patient.name.where(extension.where(url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation').value.as(code)='IDE')"
 * xpath = "f:Patient/f:name[extension/url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation' and extension/valueCode='IDE']"
 * xpathUsage = #normal
@@ -30,7 +30,7 @@ Usage: #definition
 * description = "PatientリソースのKanaName(カナ名称)に関する検索を定義します。"
 * code = #jp-kana-name
 * base = #Patient
-* type = #token
+* type = #string
 * expression = "Patient.name.where(extension.where(url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation').value.as(code)='SYL')"
 * xpath = "f:Patient/f:name[extension/@url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation' and extension/valueCode='SYL']"
 * xpathUsage = #normal


### PR DESCRIPTION
## 修正内容
漢字名・カナ名による検索の型をtoken型からstring型へ修正しました。

## 担当SWG
SWG1

## Merge依頼先
SWG1

## レビュー観点
FHIRのname検索では先頭の部分一致でもヒットさせる方針で、完全一致を強制する場合には:exactモディファイアを使います。https://hl7.org/fhir/R4/search.html#string
JPでは完全一致を標準としたいという積極的な意図でtoken型としたということでしたら、詳細について議論させてください。

## 補足

