### PR TITLE
Feature/kohe jp patinet.name

### DIFF
--- a/input/fsh/profiles/JP_HumanName.fsh
+++ b/input/fsh/profiles/JP_HumanName.fsh
@@ -12,12 +12,9 @@ Description: "このプロファイルはHumanName DataTypeに対して、患者
 * . ^short = "Name of a human - parts and usage　人の名前情報、その一部分と使い方"
 * . ^definition = "A human's name with the ability to identify parts and usage.\r\n\r\n識別のための人の名前情報、"
 * . ^comment = "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts might or might not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.\r\n\r\n名前が変更されたり、違っていると指摘されたり、コンテキストによって使われる名前が異なる場合がある。名前は、コンテキストに応じて重要性が異なるさまざまなタイプの部分に分割される場合があり、部分への分割は必ずしも重要ではない。個人名の場合、さまざまな部分に暗黙の意味が含まれている場合と含まれていない場合がある。さまざまな文化が名前の部分にさまざまな重要性を関連付けており、システムが世界中の名前の部分を気にする必要がある程度は大きく異なる。"
-* extension ^slicing.discriminator.type = #value
-* extension ^slicing.discriminator.path = "url"
-* extension ^slicing.rules = #open
-* extension contains $iso21090-EN-representation named NameRepresentationUse 1..*
-* extension[NameRepresentationUse] ^definition = "Name Representation.\r\n\r\n名前の表現方法"
-* extension[NameRepresentationUse] ^comment = "The transcription of the name - how it is represented (for e.g. Japanese names).\r\n\r\n名前の文字起こし-表現方法（日本の名前など）。"
+* extension contains $iso21090-EN-representation named nameRepresentationUse 1..*
+* extension[nameRepresentationUse] ^definition = "Name Representation.\r\n\r\n名前の表現方法"
+* extension[nameRepresentationUse] ^comment = "The transcription of the name - how it is represented (for e.g. Japanese names).\r\n\r\n名前の文字起こし-表現方法（日本の名前など）。"
 * use ^definition = "Identifies the purpose for this name.\r\n\r\nこの名前の使用目的"
 * use ^comment = "Applications can assume that a name is current unless it explicitly says that it is temporary or old.\r\n\r\nアプリケーションは、名前が明示的に一時的な名前（temp ）あるいは以前の名前だ（old ）と設定されていない場合には、現時点での名前だとみなしてよい。"
 * use ^requirements = "Allows the appropriate name for a particular context of use to be selected from among a set of names.\r\n\r\n一連の名前の中から、特定の使用状況に適した名前を選択できるようになる。"

--- a/input/fsh/profiles/JP_Patient.fsh
+++ b/input/fsh/profiles/JP_Patient.fsh
@@ -50,11 +50,16 @@ Description: "このプロファイルはPatientリソースに対して、患�
 * name only JP_HumanName
 * name ^slicing.discriminator.type = #value
 * name ^slicing.discriminator.path = "extension.value[x]"
-* name ^slicing.rules = #closed
+* name ^slicing.rules = #open
 * name ^definition = "A name associated with the individual.\r\n\r\n個人に関連付けられた名前。"
 * name ^comment = "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts might or might not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.\r\n\r\n患者は、用途や適用期間が異なる複数の名前を持つ場合があります。動物の場合、名前は人間によって割り当てられて使用され、同じパターンを持つという意味で「HumanName」です。\r\n\r\n--------SWG3 コメント-----------\r\n\r\nFHIRデータ型仕様に従って、以下の案とした。\r\n\r\n・姓名分割できる場合は、名前パート HumanName.familyとHumanName.givenに指定する。\r\n\r\n・ミドルネームがある場合は、given に指定する（givenは繰り返し可能）\r\n\r\n・姓名に分割できない場合は、HumanName.text にフルネームを指定する。\r\n\r\n・各名前パートとtext は、両方存在してもよい。\r\n\r\n　※診療文書構造化記述規約等では、姓に指定するとなっていた。\r\n\r\n・漢字氏名、カナ氏名の区別は、iso21090-EN-representation を使用する。\r\n\r\n・漢字、カナの指定がない場合やローマ字名の場合などはデフォルトスライスが適用される。"
 * name ^requirements = "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.\r\n\r\n複数の名前で患者を追跡できる必要があります。例としては、正式名とパートナー名があります。"
 * name ^mustSupport = false
+* name  contains
+        kanji   0..1
+    and kana    0..1
+* name[kanji].extension.valueCode = #IDE
+* name[kana].extension.valueCode = #SYL
 * telecom ^short = "A contact detail for the individual　個人に連絡するための連絡先の詳細"
 * telecom ^definition = "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.\r\n\r\n個人に連絡するための連絡先の詳細（電話番号や電子メールアドレスなど）。"
 * telecom ^comment = "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).\r\n\r\n患者は、さまざまな用途または適用期間違いで連絡先を複数の方法を持っている場合があります。緊急時連絡先として、また身元確認を支援するためのオプションが必要になる場合があります。患者当人に直接連絡できない場合がありますが、患者を代理できる別の関係者（自宅の電話、またはペットの所有者の電話）を設定する場合もあります。"

--- a/input/fsh/profiles/JP_Patient.fsh
+++ b/input/fsh/profiles/JP_Patient.fsh
@@ -18,7 +18,7 @@ Description: "このプロファイルはPatientリソースに対して、患�
 * extension contains
     $patient-religion named religion 0..* and
     $patient-birthPlace named birthPlace 0..1 and
-    JP_Patient_Race named Race 0..*
+    JP_Patient_Race named race 0..*
 * extension[religion] ^short = "患者の宗教"
 * extension[religion] ^definition = "The patient's professed religious affiliations.\r\n患者の公言された宗教的所属。"
 * extension[religion] ^comment = "患者の宗教をValueSet(v3.ReligiousAffiliation)より選択する。輸血や食事で考慮が必要な場合がある。\r\n\r\n1013 キリスト教\r\n1020 ヒンドゥー教\r\n1023 イスラム教\r\n\r\nなど"
@@ -27,10 +27,10 @@ Description: "このプロファイルはPatientリソースに対して、患�
 * extension[birthPlace] ^definition = "The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\r\n患者の登録された出生地。システムは、birthPlaceアドレスを個別の要素に格納しない場合、address.textを使用してよい。"
 * extension[birthPlace] ^comment = "患者の生誕地をAddress型で表現する"
 * extension[birthPlace] ^min = 0
-* extension[Race] ^short = "患者の人種。"
-* extension[Race] ^definition = "Optional Extension Element - found in all resources.\r\nオプションの拡張要素-すべてのリソースで使用できる。"
-* extension[Race] ^comment = "患者の人種をValueSet(Race)より選択する。\r\n\r\n2034-7 中国人\r\n2039-6 日本人\r\n2040-4 韓国人\r\n2108-9 ヨーロッパ人\r\n2110-5 英国人\r\n2111-3 フランス人\r\n2112-1 ドイツ人\r\n\r\nなど"
-* extension[Race] ^min = 0
+* extension[race] ^short = "患者の人種。"
+* extension[race] ^definition = "Optional Extension Element - found in all resources.\r\nオプションの拡張要素-すべてのリソースで使用できる。"
+* extension[race] ^comment = "患者の人種をValueSet(Race)より選択する。\r\n\r\n2034-7 中国人\r\n2039-6 日本人\r\n2040-4 韓国人\r\n2108-9 ヨーロッパ人\r\n2110-5 英国人\r\n2111-3 フランス人\r\n2112-1 ドイツ人\r\n\r\nなど"
+* extension[race] ^min = 0
 * identifier 1..
 * identifier ^definition = "An identifier for this patient.\r\n\r\nこの患者の識別子。"
 * identifier ^comment = "【JP_CORE】\r\nIDの名前空間を表す Patient.identifier.system と ID値そのものを表す Patient.identifier.value の組み合わせとして表現する。\r\nPatient.identifier.system には、\r\n　urn:oid:1.2.392.100495.20.3.51.医療機関識別OID番号\r\nを使用する。\r\n医療機関識別OID番号は、患者IDの発行者である医療機関の識別するもので、保険医療機関の場合、都道府県番号２桁から始まる10桁の医療機関番号（都道府県2桁、保険点数表コード1桁、保険医療機関番号７桁を連結したもの）または、特定健診・特定保健指導機関の医療機関番号10桁の先頭に１をつけた11桁とする。\r\n保険点数表コード1桁は医科は１，歯科は３である。\r\n医療機関コードを持たない場合、「[9]＋当該施設の電話番号下 9 桁」を医療機関コードとして、その先頭に１をつけた11桁とする。\r\n\r\n例：医療機関コード「1312345670」の場合「urn:oid:1.2.392.100495.20.3.51.11312345670」\r\nなお、urn:oid:1.2.392.100495.20.3.51　の部分は、厚生労働省 電子処方箋CDA 記述仕様第1版（平成30年7月）付表2 OID一覧において患者番号として割り当てられたOIDのURL型である。\r\n\r\n地域医療連携ネットワークの地域患者IDを指定する場合も同様に、地域患者IDを識別する名前空間（IHE ITI PIX等で使用されるOID等）を system に使用することができる。"
@@ -48,18 +48,20 @@ Description: "このプロファイルはPatientリソースに対して、患�
 * active ^meaningWhenMissing = "This resource is generally assumed to be active if no value is provided for the active element\r\n\r\nアクティブな要素に値が指定されていない場合、このリソースは通常アクティブであると想定されます"
 * active ^isModifierReason = "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid この要素は、レコードの有効・無効判定を示すステータス要素であるため、修飾子としてラベル付けされます"
 * name only JP_HumanName
-* name ^slicing.discriminator.type = #value
-* name ^slicing.discriminator.path = "extension.value[x]"
-* name ^slicing.rules = #open
 * name ^definition = "A name associated with the individual.\r\n\r\n個人に関連付けられた名前。"
 * name ^comment = "Names may be changed, or repudiated, or people may have different names in different contexts. Names may be divided into parts of different type that have variable significance depending on context, though the division into parts does not always matter. With personal names, the different parts might or might not be imbued with some implicit meaning; various cultures associate different importance with the name parts and the degree to which systems must care about name parts around the world varies widely.\r\n\r\n患者は、用途や適用期間が異なる複数の名前を持つ場合があります。動物の場合、名前は人間によって割り当てられて使用され、同じパターンを持つという意味で「HumanName」です。\r\n\r\n--------SWG3 コメント-----------\r\n\r\nFHIRデータ型仕様に従って、以下の案とした。\r\n\r\n・姓名分割できる場合は、名前パート HumanName.familyとHumanName.givenに指定する。\r\n\r\n・ミドルネームがある場合は、given に指定する（givenは繰り返し可能）\r\n\r\n・姓名に分割できない場合は、HumanName.text にフルネームを指定する。\r\n\r\n・各名前パートとtext は、両方存在してもよい。\r\n\r\n　※診療文書構造化記述規約等では、姓に指定するとなっていた。\r\n\r\n・漢字氏名、カナ氏名の区別は、iso21090-EN-representation を使用する。\r\n\r\n・漢字、カナの指定がない場合やローマ字名の場合などはデフォルトスライスが適用される。"
 * name ^requirements = "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.\r\n\r\n複数の名前で患者を追跡できる必要があります。例としては、正式名とパートナー名があります。"
 * name ^mustSupport = false
-* name  contains
+* name.extension[nameRepresentationUse] ^slicing.discriminator.type = #value
+* name.extension[nameRepresentationUse]  ^slicing.discriminator.path = value[x]"
+* name.extension[nameRepresentationUse]  ^slicing.rules = #open
+* name.extension[nameRepresentationUse]  contains
         kanji   0..1
     and kana    0..1
-* name[kanji].extension.valueCode = #IDE
-* name[kana].extension.valueCode = #SYL
+* name.extension[nameRepresentationUse][kanji].valueCode = #IDE
+* name.extension[nameRepresentationUse][kanji] ^short = "漢字氏名"
+* name.extension[nameRepresentationUse][kana].valueCode = #SYL
+* name.extension[nameRepresentationUse][kana] ^short = "全角カナ氏名"
 * telecom ^short = "A contact detail for the individual　個人に連絡するための連絡先の詳細"
 * telecom ^definition = "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.\r\n\r\n個人に連絡するための連絡先の詳細（電話番号や電子メールアドレスなど）。"
 * telecom ^comment = "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).\r\n\r\n患者は、さまざまな用途または適用期間違いで連絡先を複数の方法を持っている場合があります。緊急時連絡先として、また身元確認を支援するためのオプションが必要になる場合があります。患者当人に直接連絡できない場合がありますが、患者を代理できる別の関係者（自宅の電話、またはペットの所有者の電話）を設定する場合もあります。"


### PR DESCRIPTION
## 修正内容
JP_Patient.name にSYLとIDEの記述が明示的に存在していなかったので、extension[nameRepresentationUse]にkanjiとkanaのsliceを定義した。合わせてJP_HumanNameに不要と思われるslice定義が存在していなのを削除。JP_Patientのextension[race]とJP_HumanName.extension[nameRepresentationUse]のそれぞれslice名の先頭文字を英字小文字に変更（慣習に合わせるため）

## 担当SWG
<!-- (SWG[1-6] もしくは アカウント名) -->
SWG3

## Merge依頼先
<!-- (SGW[1-6] もしくは アカウント名) -->
<!-- 個人を指定するにはあわせてReviewersに設定すること-->
SWG3

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->

## 補足

