### PR TITLE
漢字、カナ名称検索パラメータの廃止

### DIFF
--- a/input/fsh/searchparameters/JP_Patient_SP.fsh
+++ b/input/fsh/searchparameters/JP_Patient_SP.fsh
@@ -1,48 +1,3 @@
-Instance: jp-patient-kanjiname-sp
-InstanceOf: SearchParameter
-Usage: #definition
-* url = "http://jpfhir.jp/fhir/core/SearchParameter/JP_Patient_KanjiName_SP"
-* name = "JP_Patient_KanjiName_SP"
-* status = #draft
-* date = "2022-03-23"
-* description = "PatientリソースのKanjiName(漢字名称)に関する検索を定義します。"
-* code = #jp-kanji-name
-* base = #Patient
-* type = #string
-* expression = "Patient.name.where(extension.where(url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation').value.as(code)='IDE')"
-* xpath = "f:Patient/f:name[extension/url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation' and extension/valueCode='IDE']"
-* xpathUsage = #normal
-* multipleOr = true
-* multipleOr.extension.url = $capabilityStatement-expectation
-* multipleOr.extension.valueCode = #MAY
-* multipleAnd = true
-* multipleAnd.extension.url = $capabilityStatement-expectation
-* multipleAnd.extension.valueCode = #MAY
-
-
-Instance: jp-patient-kananame-sp
-InstanceOf: SearchParameter
-Usage: #definition
-* url = "http://jpfhir.jp/fhir/core/SearchParameter/JP_Patient_KanaName_SP"
-* name = "JP_Patient_KanaName_SP"
-* status = #draft
-* date = "2022-03-23"
-* description = "PatientリソースのKanaName(カナ名称)に関する検索を定義します。"
-* code = #jp-kana-name
-* base = #Patient
-* type = #string
-* expression = "Patient.name.where(extension.where(url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation').value.as(code)='SYL')"
-* xpath = "f:Patient/f:name[extension/@url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation' and extension/valueCode='SYL']"
-* xpathUsage = #normal
-* multipleOr = true
-* multipleOr.extension.url = $capabilityStatement-expectation
-* multipleOr.extension.valueCode = #MAY
-* multipleAnd = true
-* multipleAnd.extension.url = $capabilityStatement-expectation
-* multipleAnd.extension.valueCode = #MAY
-
-
-
 Instance: jp-patient-kanasort-sp
 InstanceOf: SearchParameter
 Usage: #definition
@@ -63,4 +18,3 @@ Usage: #definition
 * multipleAnd = true
 * multipleAnd.extension.url = $capabilityStatement-expectation
 * multipleAnd.extension.valueCode = #MAY
-

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -27,6 +27,7 @@
 [JP_FamilyMemberHistory]: StructureDefinition-jp-familymemberhistory.html
 [JP_HumanName]: StructureDefinition-jp-humanname.html
 [JP_ImagingStudy_Radiology]: StructureDefinition-jp-imagingstudy-radiology.html
+[JP_Immunization]: StructureDefinition-jp-immunization.html
 [JP_Location]: StructureDefinition-jp-location.html
 [JP_Medication]: StructureDefinition-jp-medication.html
 [JP_MedicationAdministration_Injection]: StructureDefinition-jp-medicationadministration-injection.html
@@ -53,6 +54,9 @@
 [JP_Coverage_InsuredPersonNumber]: StructureDefinition-jp-coverage-insuredpersonnumber.html
 [JP_Coverage_InsuredPersonSubNumber]: StructureDefinition-jp-coverage-insuredpersonsubnumber.html
 [JP_Coverage_InsuredPersonSymbol]: StructureDefinition-jp-coverage-insuredpersonsymbol.html
+[JP_Immunization_CertificatedDate]: StructureDefinition-jp-immunization-certificateddate.html
+[JP_Immunization_DueDateOfNextDose]: StructureDefinition-jp-immunization-duedateofnextdose.html
+[JP_Immunization_ManufacturedDate]: StructureDefinition-jp-immunization-manufactureddate.html
 [JP_Medication_Ingredient_DrugNo]: StructureDefinition-jp-medication-ingredient-drugno.html
 [JP_Medication_IngredientStrength_StrengthType]: StructureDefinition-jp-medication-ingredientstrength-strengthtype.html
 [JP_MedicationAdministration_Dosage_DosageComment]: StructureDefinition-jp-medicationadministration-dosage-dosagecomment.html
@@ -91,8 +95,8 @@
 [JP_Organization_InsuranceOrganizationNo_SP]: SearchParameter-jp-organization-insuranceorganizationno-sp.html
 [JP_Organization_PrefectureNo_SP]: SearchParameter-jp-organization-prefectureno-sp.html
 [JP_Patient_KanaName_SP]: SearchParameter-jp-patient-kananame-sp.html
-[JP_Patient_KanjiName_SP]: SearchParameter-jp-patient-kanjiname-sp.html
 [JP_Patient_KanaSort_SP]: SearchParameter-jp-patient-kanasort-sp.html
+[JP_Patient_KanjiName_SP]: SearchParameter-jp-patient-kanjiname-sp.html
 
 <!-- CodeSystem -->
 [JP_JFAGY_CS]: CodeSystem-jp-jfagy-cs.html

--- a/input/pagecontent/group-searchParameter.md
+++ b/input/pagecontent/group-searchParameter.md
@@ -7,8 +7,6 @@
 * [JP_Organization_InsuranceOrganizationCategory_SP]
 * [JP_Organization_InsuranceOrganizationNo_SP]
 * [JP_Organization_PrefectureNo_SP]
-* [JP_Patient_KanjiName_SP]
-* [JP_Patient_KanaName_SP]
 * [JP_Patient_KanaSort_SP]
 
 ### FHIR Base 定義済み検索パラメーター


### PR DESCRIPTION
## 修正内容
WG1検討の結果、漢字・カナ名称の検索パラメターの利用用途がまだ不明なためJPCoreとしては定義しなくても
よいとの結論になりました。確認を含めてmergeをしていただくようお願いします。
fix #76

## 担当SWG
SWG1

## Merge依頼先
SWG3

## レビュー観点
削除により他の影響がないかを確認をお願いします。

