### PR TITLE
サンプルインスタンスを実装ガイドに取り込む

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-medication-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medication-notes.md
@@ -68,8 +68,143 @@ Medicationリソースは、以下の制約を満たさなければならない�
 Medication リソースは単体として用いられないため、検索などはMedicationRequestなどの一部として行われる。
 
 ### サンプル
+注射関係のMedicationRequest、MedicationDisepense、MedicationAdministrationリソースから参照されるサンプルを示す。
+[MedicationRequest(注射)][JP_MedicationRequest_Injection]や[MedicationDispense(注射)][JP_MedicationDispense_Injection]、[MedicationAdministration(注射)][JP_MedicationAdministration_Injection]も参照すること。
 
-[MedicationRequest(注射)][JP_MedicationRequest_Injection]や[MedicationDispense(注射)][JP_MedicationDispense_Injection]、[MedicationAdministration(注射)][JP_MedicationAdministration_Injection]を参照すること。
+#### ホリゾン注射液１０ｍｇ
+```json
+{
+  "resourceType": "Medication",
+  "id": "jp-medication-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medication-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><h3>Ingredients</h3><table class=\"grid\"><tr><td>-</td><td><b>Extension</b></td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td>*</td><td></td><td>ホリゾン注射液１０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#100558502)</span></td><td>1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></td></tr></table></div>"
+  },
+  "status": "active",
+  "ingredient": [
+    {
+      "extension": [
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo",
+          "valueInteger": 1
+        }
+      ],
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.100495.20.2.74",
+            "code": "100558502",
+            "display": "ホリゾン注射液１０ｍｇ"
+          }
+        ]
+      },
+      "strength": {
+        "extension": [
+          {
+            "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_IngredientStrength_StrengthType",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "urn:oid:1.2.392.100495.20.2.22",
+                  "code": "1",
+                  "display": "製剤量"
+                }
+              ]
+            }
+          }
+        ],
+        "numerator": {
+          "value": 1,
+          "unit": "アンプル",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "AMP"
+        },
+        "denominator": {
+          "value": 1,
+          "unit": "回",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "KAI"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### ソリタ－Ｔ３号輸液５００ｍＬ　１本とアドナ注（静脈用）５０ｍｇ／１０ｍＬ　１アンプルの混注
+```json
+{
+  "resourceType": "Medication",
+  "id": "jp-medication-example-2",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medication-example-2\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><blockquote><p><b>ingredient</b></p><p><b>item</b>: ソリタ－Ｔ３号輸液５００ｍＬ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#107750602)</span></p><p><b>strength</b>: 1 本<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code HON = 'HON')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></p></blockquote><blockquote><p><b>ingredient</b></p><p><b>item</b>: アドナ注（静脈用）５０ｍｇ／１０ｍＬ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#108010001)</span></p><p><b>strength</b>: 1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></p></blockquote></div>"
+  },
+  "status": "active",
+  "ingredient": [
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.100495.20.2.74",
+            "code": "107750602",
+            "display": "ソリタ－Ｔ３号輸液５００ｍＬ"
+          }
+        ]
+      },
+      "strength": {
+        "numerator": {
+          "value": 1,
+          "unit": "本",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "HON"
+        },
+        "denominator": {
+          "value": 1,
+          "unit": "回",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "KAI"
+        }
+      }
+    },
+    {
+      "itemCodeableConcept": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.100495.20.2.74",
+            "code": "108010001",
+            "display": "アドナ注（静脈用）５０ｍｇ／１０ｍＬ"
+          }
+        ]
+      },
+      "strength": {
+        "numerator": {
+          "value": 1,
+          "unit": "アンプル",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "AMP"
+        },
+        "denominator": {
+          "value": 1,
+          "unit": "回",
+          "system": "urn:oid:1.2.392.100495.20.2.101",
+          "code": "KAI"
+        }
+      }
+    }
+  ]
+}
+```
 
 ### 各種コメントの記述方法
 

--- a/input/intro-notes/StructureDefinition-jp-medicationadministration-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationadministration-injection-notes.md
@@ -248,10 +248,9 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
-[JAHIS注射データ交換規約Ver.2.1C](https://www.jahis.jp/standard/detail/id=590)に記載されている下記の注射実施メッセージをFHIRで表現する場合のサンプル
+[JAHIS注射データ交換規約Ver.2.1C](https://www.jahis.jp/standard/detail/id=590)に記載されている下記の注射実施をFHIRで表現する場合のサンプルを示す。
 
-<details>
-<summary>（２）実施情報（ワンショット）</summary>
+#### （２）実施情報（ワンショット）
 
 | 項目名 | 項目値 | 備考 |
 | :--- | :--- | :--- |
@@ -280,10 +279,26 @@ HTTP/1.1 200 OK
 ```json
 {
   "resourceType": "MedicationAdministration",
+  "id": "jp-medicationadministration-injection-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationAdministration_Injection"
+    ]
+  },
+  "text": {
+    "status": "extensions",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-injection-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationadministration-injection.html\">JP Core MedicationAdministration Injection Profile</a></p></div><p><b>JP Core MedicationAdministration RequestDepartment Extension</b>: 内科 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#01)</span></p><p><b>JP Core MedicationAdministration Requester Extension</b>: <a href=\"Practitioner-jp-practionner-example-male-1.html\">Practitioner/jp-practionner-example-male-1: 大阪 一郎</a> \" 大阪\"</p><p><b>JP Core MedicationAdministration RequestAuthoredOn Extension</b>: 2016-07-01 12:00:00+0900</p><p><b>JP Core MedicationAdministration Location Extension</b>: <a href=\"Location-jp-location-example-ward.html\">Location/jp-location-example-ward: 09A病棟 021病室 4ベッド</a> \"09A病棟 021病室 4ベッド\"</p><p><b>identifier</b>: id: 123456789012345.1, id: 1, id: 1</p><p><b>status</b>: completed</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: <a name=\"jp-medicationadministration-injection-medication-example-1\"> </a></p><blockquote><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-injection-medication-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><h3>Ingredients</h3><table class=\"grid\"><tr><td>-</td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td>*</td><td>ホリゾン注射液１０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#100558502)</span></td><td>1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></td></tr></table></blockquote><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>effective</b>: 2016-07-01 10:05:21+0900 --&gt; 2016-07-01 10:05:21+0900</p><h3>Performers</h3><table class=\"grid\"><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Performer <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-med-admin-perform-function.html\">MedicationAdministration Performer Function Codes</a>#performer)</span></td><td><a href=\"Practitioner-jp-practionner-example-male-1.html\">Practitioner/jp-practionner-example-male-1: 愛知 太郎</a> \" 大阪\"</td></tr></table><p><b>request</b>: <a href=\"MedicationRequest-jp-medicationrequest-injection-example-1.html\">MedicationRequest/jp-medicationrequest-injection-example-1</a></p><p><b>device</b>: <a name=\"jp-medicationadministration-injection-device-example-1\"> </a></p><blockquote><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-injection-device-example-1\" </p></div><p><b>type</b>: シリンジ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (99ILL#01)</span></p></blockquote><h3>Dosages</h3><table class=\"grid\"><tr><td>-</td><td><b>Extension</b></td><td><b>Site</b></td><td><b>Route</b></td><td><b>Method</b></td><td><b>Dose</b></td></tr><tr><td>*</td><td></td><td> <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></td><td>Intravenous <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0162.html\">routeOfAdministration</a>#IV)</span></td><td>静注(末梢) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (99ILL#101)</span></td><td>2 mL<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mL = 'mL')</span></td></tr></table></div>"
+  },
   "contained": [
     {
       "resourceType": "Medication",
-      "id": "medication1",
+      "id": "jp-medicationadministration-injection-medication-example-1",
+      "meta": {
+        "profile": [
+          "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+        ]
+      },
+      "status": "active",
       "ingredient": [
         {
           "itemCodeableConcept": {
@@ -314,13 +329,13 @@ HTTP/1.1 200 OK
     },
     {
       "resourceType": "BodyStructure",
-      "id": "bodystructure1",
+      "id": "jp-medicationadministration-injection-bodystructure-example-1",
       "location": {
         "coding": [
           {
             "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
             "code": "ARM",
-            "display": "腕"
+            "display": "Arm"
           }
         ]
       },
@@ -330,18 +345,18 @@ HTTP/1.1 200 OK
             {
               "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
               "code": "R",
-              "display": "右"
+              "display": "Right"
             }
           ]
         }
       ],
       "patient": {
-        "reference": "Patient/1"
+        "reference": "Patient/jp-patient-example-1"
       }
     },
     {
       "resourceType": "Device",
-      "id": "device1",
+      "id": "jp-medicationadministration-injection-device-example-1",
       "type": {
         "coding": [
           {
@@ -369,8 +384,8 @@ HTTP/1.1 200 OK
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Requester",
       "valueReference": {
-        "reference": "Practitioner/2",
-        "display": "医師 一郎"
+        "reference": "Practitioner/jp-practionner-example-male-1",
+        "display": "大阪 一郎"
       }
     },
     {
@@ -380,7 +395,7 @@ HTTP/1.1 200 OK
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Location",
       "valueReference": {
-        "reference": "Location/1",
+        "reference": "Location/jp-location-example-ward",
         "display": "09A病棟 021病室 4ベッド"
       }
     }
@@ -388,7 +403,7 @@ HTTP/1.1 200 OK
   "identifier": [
     {
       "system": "http://www.example.com/fhir/order-number",
-      "value": "123456789012345"
+      "value": "123456789012345.1"
     },
     {
       "system": "urn:oid:1.2.392.100495.20.3.81",
@@ -405,16 +420,15 @@ HTTP/1.1 200 OK
       {
         "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
         "code": "I",
-        "display": "入院オーダ"
+        "display": "Inpatient Order"
       }
     ]
   },
   "medicationReference": {
-    "reference": "#medication1",
-    "type": "Medication"
+    "reference": "#jp-medicationadministration-injection-medication-example-1"
   },
   "subject": {
-    "reference": "Patient/1"
+    "reference": "Patient/jp-patient-example-1"
   },
   "effectivePeriod": {
     "start": "2016-07-01T10:05:21+09:00",
@@ -432,17 +446,17 @@ HTTP/1.1 200 OK
         ]
       },
       "actor": {
-        "reference": "Practitioner/1",
-        "display": "看護 花子"
+        "reference": "Practitioner/jp-practionner-example-male-1",
+        "display": "愛知 太郎"
       }
     }
   ],
   "request": {
-    "reference": "MedicationRequest/1"
+    "reference": "MedicationRequest/jp-medicationrequest-injection-example-1"
   },
   "device": [
     {
-      "reference": "#device1",
+      "reference": "#jp-medicationadministration-injection-device-example-1",
       "display": "シリンジ"
     }
   ],
@@ -458,12 +472,12 @@ HTTP/1.1 200 OK
         {
           "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
           "valueReference": {
-            "reference": "#bodystructure1",
+            "reference": "#jp-medicationadministration-injection-bodystructure-example-1",
             "display": "右腕"
           }
         },
         {
-          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Site_SiteComment",
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_DosageSite_SiteComment",
           "valueString": "左利きのため"
         }
       ]
@@ -473,17 +487,11 @@ HTTP/1.1 200 OK
         {
           "system": "http://terminology.hl7.org/CodeSystem/v2-0162",
           "code": "IV",
-          "display": "静脈内"
+          "display": "Intravenous"
         }
       ]
     },
     "method": {
-      "extension": [
-        {
-          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Method_MethodComment",
-          "valueString": "１分ほどかけて緩徐に行いました"
-        }
-      ],
       "coding": [
         {
           "system": "http://jpfhir.jp/medication/99ILL",
@@ -498,14 +506,12 @@ HTTP/1.1 200 OK
       "system": "http://unitsofmeasure.org",
       "code": "mL"
     }
-  }        
+  }
 }
 ```
 
-</details>
+#### （４）実施情報（点滴実施）
 
-<details>
-<summary>（４）実施情報（点滴実施）</summary>
 
 | 項目名 | 項目値 | 備考 |
 | :--- | :--- | :--- |
@@ -542,10 +548,26 @@ HTTP/1.1 200 OK
 ```json
 {
   "resourceType": "MedicationAdministration",
+  "id": "jp-medicationadministration-injection-example-2",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationAdministration_Injection"
+    ]
+  },
+  "text": {
+    "status": "extensions",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-injection-example-2\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationadministration-injection.html\">JP Core MedicationAdministration Injection Profile</a></p></div><p><b>JP Core MedicationAdministration RequestDepartment Extension</b>: 内科 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#01)</span></p><p><b>JP Core MedicationAdministration Requester Extension</b>: <a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1: 東京 春子</a> \" 東京\"</p><p><b>JP Core MedicationAdministration RequestAuthoredOn Extension</b>: 2016-07-01 12:00:00+0900</p><p><b>JP Core MedicationAdministration Location Extension</b>: <a href=\"Location-jp-location-example-ward.html\">Location/jp-location-example-ward: 09A病棟 021病室 4ベッド</a> \"09A病棟 021病室 4ベッド\"</p><p><b>identifier</b>: id: 123456789012345.2, id: 2, id: 2</p><p><b>status</b>: completed</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: <a name=\"jp-medicationadministration-injection-medication-example-2\"> </a></p><blockquote><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-injection-medication-example-2\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><blockquote><p><b>ingredient</b></p><p><b>item</b>: ソリタ－Ｔ３号輸液５００ｍＬ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#107750602)</span></p><p><b>strength</b>: 1 本<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code HON = 'HON')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></p></blockquote><blockquote><p><b>ingredient</b></p><p><b>item</b>: アドナ注（静脈用）５０ｍｇ／１０ｍＬ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#108010001)</span></p><p><b>strength</b>: 1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></p></blockquote></blockquote><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>effective</b>: 2016-07-01 08:05:21+0900 --&gt; 2016-07-01 01:05:43+0900</p><h3>Performers</h3><table class=\"grid\"><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Performer <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-med-admin-perform-function.html\">MedicationAdministration Performer Function Codes</a>#performer)</span></td><td><a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1: 福岡 花子</a> \" 東京\"</td></tr></table><p><b>request</b>: <a href=\"MedicationRequest-jp-medicationrequest-injection-example-2.html\">MedicationRequest/jp-medicationrequest-injection-example-2</a></p><h3>Dosages</h3><table class=\"grid\"><tr><td>-</td><td><b>Extension</b></td><td><b>Site</b></td><td><b>Route</b></td><td><b>Method</b></td><td><b>Dose</b></td></tr><tr><td>*</td><td></td><td> <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></td><td>Intravenous <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0162.html\">routeOfAdministration</a>#IV)</span></td><td>IV Push <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0165.html\">administrationMethod</a>#IVP)</span></td><td>510 mL<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mL = 'mL')</span></td></tr></table></div>"
+  },
   "contained": [
     {
       "resourceType": "Medication",
-      "id": "medication1",
+      "id": "jp-medicationadministration-injection-medication-example-2",
+      "meta": {
+        "profile": [
+          "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+        ]
+      },
+      "status": "active",
       "ingredient": [
         {
           "itemCodeableConcept": {
@@ -601,13 +623,13 @@ HTTP/1.1 200 OK
     },
     {
       "resourceType": "BodyStructure",
-      "id": "bodystructure1",
+      "id": "jp-medicationadministration-injection-bodystructure-example-2",
       "location": {
         "coding": [
           {
             "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
             "code": "ARM",
-            "display": "腕"
+            "display": "Arm"
           }
         ]
       },
@@ -617,13 +639,13 @@ HTTP/1.1 200 OK
             {
               "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
               "code": "L",
-              "display": "左"
+              "display": "Left"
             }
           ]
         }
       ],
       "patient": {
-        "reference": "Patient/1"
+        "reference": "Patient/jp-patient-example-1"
       }
     }
   ],
@@ -643,8 +665,8 @@ HTTP/1.1 200 OK
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Requester",
       "valueReference": {
-        "reference": "Practitioner/2",
-        "display": "医師 一郎"
+        "reference": "Practitioner/jp-practionner-example-female-1",
+        "display": "東京 春子"
       }
     },
     {
@@ -654,7 +676,7 @@ HTTP/1.1 200 OK
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Location",
       "valueReference": {
-        "reference": "Location/1",
+        "reference": "Location/jp-location-example-ward",
         "display": "09A病棟 021病室 4ベッド"
       }
     }
@@ -662,15 +684,15 @@ HTTP/1.1 200 OK
   "identifier": [
     {
       "system": "http://www.example.com/fhir/order-number",
-      "value": "123456789012345"
+      "value": "123456789012345.2"
     },
     {
       "system": "urn:oid:1.2.392.100495.20.3.81",
-      "value": "1"
+      "value": "2"
     },
     {
       "system": "urn:oid:1.2.392.100495.20.3.82",
-      "value": "1"
+      "value": "2"
     }
   ],
   "status": "completed",
@@ -679,16 +701,15 @@ HTTP/1.1 200 OK
       {
         "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
         "code": "I",
-        "display": "入院オーダ"
+        "display": "Inpatient Order"
       }
     ]
   },
   "medicationReference": {
-    "reference": "#medication1",
-    "type": "Medication"
+    "reference": "#jp-medicationadministration-injection-medication-example-2"
   },
   "subject": {
-    "reference": "Patient/1"
+    "reference": "Patient/jp-patient-example-1"
   },
   "effectivePeriod": {
     "start": "2016-07-01T08:05:21+09:00",
@@ -706,13 +727,13 @@ HTTP/1.1 200 OK
         ]
       },
       "actor": {
-        "reference": "Practitioner/1",
-        "display": "看護 花子"
+        "reference": "Practitioner/jp-practionner-example-female-1",
+        "display": "福岡 花子"
       }
     }
   ],
   "request": {
-    "reference": "MedicationRequest/1"
+    "reference": "MedicationRequest/jp-medicationrequest-injection-example-2"
   },
   "dosage": {
     "extension": [
@@ -734,7 +755,7 @@ HTTP/1.1 200 OK
         {
           "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
           "valueReference": {
-            "reference": "#bodystructure1",
+            "reference": "#jp-medicationadministration-injection-bodystructure-example-2",
             "display": "左腕"
           }
         }
@@ -745,7 +766,7 @@ HTTP/1.1 200 OK
         {
           "system": "http://terminology.hl7.org/CodeSystem/v2-0162",
           "code": "IV",
-          "display": "静脈内"
+          "display": "Intravenous"
         }
       ]
     },
@@ -754,7 +775,7 @@ HTTP/1.1 200 OK
         {
           "system": "http://terminology.hl7.org/CodeSystem/v2-0165",
           "code": "IVP",
-          "display": "IVプッシュ"
+          "display": "IV Push"
         }
       ]
     },
@@ -781,8 +802,6 @@ HTTP/1.1 200 OK
   }
 }
 ```
-
-</details>
 
 ## 注意事項
 

--- a/input/intro-notes/StructureDefinition-jp-medicationadministration-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationadministration-notes.md
@@ -236,7 +236,7 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
-[JAHIS処方データ交換規約 Ver.3.0C](https://www.jahis.jp/standard/detail/id=564)の137ページに記載されている下記の処方実施をFHIRで表現する場合について解説する。
+[JAHIS処方データ交換規約 Ver.3.0C](https://www.jahis.jp/standard/detail/id=564)の137ページに記載されている下記の処方実施をFHIRで表現する場合のサンプルを示す。
 ```
 投与日時　2016/08/25 08:30
 Rp1
@@ -266,6 +266,16 @@ Rp1
 ```json
 {
   "resourceType": "MedicationAdministration",
+  "id": "jp-medicationadministration-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationAdministration"
+    ]
+  },
+  "text": {
+    "status": "extensions",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationadministration.html\">JP Core MedicationAdministration Profile</a></p></div><p><b>JP Core MedicationAdministration RequestDepartment Extension</b>: 内科 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#01)</span></p><p><b>JP Core MedicationAdministration Requester Extension</b>: <a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1: 東京 春子</a> \" 東京\"</p><p><b>JP Core MedicationAdministration RequestAuthoredOn Extension</b>: 2016-08-25 12:00:00+0900</p><p><b>JP Core MedicationAdministration Location Extension</b>: <a href=\"Location-jp-location-example-ward.html\">Location/jp-location-example-ward: 09A病棟 021病室 4ベッド</a> \"09A病棟 021病室 4ベッド\"</p><p><b>identifier</b>: id: 12345678, id: 1, id: 1</p><p><b>status</b>: completed</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: ムコダイン錠２５０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#103835401)</span></p><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>effective</b>: 2016-08-25 08:30:00+0900</p><h3>Performers</h3><table class=\"grid\"><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Performer <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-med-admin-perform-function.html\">MedicationAdministration Performer Function Codes</a>#performer)</span></td><td><a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1: 福岡 花子</a> \" 東京\"</td></tr></table><p><b>request</b>: <a href=\"MedicationRequest-jp-medicationrequest-example-1.html\">MedicationRequest/jp-medicationrequest-example-1</a></p><h3>Dosages</h3><table class=\"grid\"><tr><td>-</td><td><b>Route</b></td><td><b>Method</b></td><td><b>Dose</b></td></tr><tr><td>*</td><td>経口 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#0)</span></td><td>内服 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#1)</span></td><td>1 錠<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code TAB = 'TAB')</span></td></tr></table></div>"
+  },
   "extension": [
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_RequestDepartment",
@@ -280,20 +290,20 @@ Rp1
       }
     },
     {
-      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministrationRequester",
+      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Requester",
       "valueReference": {
-        "reference": "Practitioner/2",
-        "display": "医師 春子"
+        "reference": "Practitioner/jp-practionner-example-female-1",
+        "display": "東京 春子"
       }
     },
     {
-      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministrationRequestAuthoredOn",
+      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_RequestAuthoredOn",
       "valueDateTime": "2016-08-25T00:00:00+09:00"
     },
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Location",
       "valueReference": {
-        "reference": "Location/1",
+        "reference": "Location/jp-location-example-ward",
         "display": "09A病棟 021病室 4ベッド"
       }
     }
@@ -318,7 +328,7 @@ Rp1
       {
         "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
         "code": "I",
-        "display": "入院オーダ"
+        "display": "Inpatient Order"
       }
     ]
   },
@@ -332,7 +342,7 @@ Rp1
     ]
   },
   "subject": {
-    "reference": "Patient/1"
+    "reference": "Patient/jp-patient-example-1"
   },
   "effectiveDateTime": "2016-08-25T08:30:00+09:00",
   "performer": [
@@ -347,13 +357,13 @@ Rp1
         ]
       },
       "actor": {
-        "reference": "Practitioner/1",
-        "display": "看護師 夏子"
+        "reference": "Practitioner/jp-practionner-example-female-1",
+        "display": "福岡 花子"
       }
     }
   ],
   "request": {
-    "reference": "MedicationRequest/1"
+    "reference": "MedicationRequest/jp-medicationrequest-example-1"
   },
   "dosage": {
     "route": {
@@ -380,7 +390,7 @@ Rp1
       "system": "urn:oid:1.2.392.100495.20.2.101",
       "code": "TAB"
     }
-  }        
+  }
 }
 ```
 
@@ -388,6 +398,16 @@ Rp1
 ```json
 {
   "resourceType": "MedicationAdministration",
+  "id": "jp-medicationadministration-example-2",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationAdministration"
+    ]
+  },
+  "text": {
+    "status": "extensions",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationadministration-example-2\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationadministration.html\">JP Core MedicationAdministration Profile</a></p></div><p><b>JP Core MedicationAdministration RequestDepartment Extension</b>: 内科 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#01)</span></p><p><b>JP Core MedicationAdministration Requester Extension</b>: <a href=\"Practitioner-jp-practionner-example-male-1.html\">Practitioner/jp-practionner-example-male-1: 大阪 一郎</a> \" 大阪\"</p><p><b>JP Core MedicationAdministration RequestAuthoredOn Extension</b>: 2016-08-25 12:00:00+0900</p><p><b>identifier</b>: id: 12345678, id: 1, id: 2</p><p><b>status</b>: stopped</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: パンスポリンＴ錠１００ １００ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#110626901)</span></p><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>effective</b>: 2016-08-25 08:30:00+0900</p><p><b>request</b>: <a href=\"MedicationRequest-jp-medicationrequest-example-2.html\">MedicationRequest/jp-medicationrequest-example-2</a></p></div>"
+  },
   "extension": [
     {
       "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_RequestDepartment",
@@ -402,14 +422,14 @@ Rp1
       }
     },
     {
-      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministrationRequester",
+      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_Requester",
       "valueReference": {
-        "reference": "Practitioner/2",
-        "display": "医師 春子"
+        "reference": "Practitioner/jp-practionner-example-male-1",
+        "display": "大阪 一郎"
       }
     },
     {
-      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministrationRequestAuthoredOn",
+      "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationAdministration_RequestAuthoredOn",
       "valueDateTime": "2016-08-25T00:00:00+09:00"
     }
   ],
@@ -433,7 +453,7 @@ Rp1
       {
         "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
         "code": "I",
-        "display": "入院オーダ"
+        "display": "Inpatient Order"
       }
     ]
   },
@@ -447,12 +467,12 @@ Rp1
     ]
   },
   "subject": {
-    "reference": "Patient/1"
+    "reference": "Patient/jp-patient-example-1"
   },
   "effectiveDateTime": "2016-08-25T08:30:00+09:00",
   "request": {
-    "reference": "MedicationRequest/2"
-  }        
+    "reference": "MedicationRequest/jp-medicationrequest-example-2"
+  }
 }
 ```
 

--- a/input/intro-notes/StructureDefinition-jp-medicationdispense-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationdispense-injection-notes.md
@@ -268,198 +268,249 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
-
-<details>
-<summary><b>ホリゾン注射液１０ｍｇ１アンプルを左腕に静脈注射(クリックで展開)</b></summary>
-<div>
-
+ホリゾン注射液１０ｍｇ１アンプルを左腕に静脈注射する処方例をFHIRで表現する場合のサンプルを示す。
 ```JSON
 {
-    "resourceType": "MedicationRequest",
-    "contained": [{
-            "resourceType": "Medication",
-            "id": "medication1",
-            "ingredient": [{
-                "extension": [{
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo",
-                    "valueInteger": 1
-                }],
-                "itemCodeableConcept": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.100495.20.2.74",
-                        "code": "100558502",
-                        "display": "ホリゾン注射液１０ｍｇ"
-                    }]
-                },
-                "strength": {
-                    "extension": [{
-                        "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Strength_StrengthType",
-                        "valueCodeableConcept": {
-                            "coding": [{
-                                "system": "urn:oid:1.2.392.100495.20.2.22",
-                                "code": "1",
-                                "display": "製剤量"
-                            }]
-                        }
-                    }],
-                    "numerator": {
-                        "value": 1,
-                        "unit": "アンプル",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "AMP"
-                    },
-                    "denominator": {
-                        "value": 1,
-                        "unit": "回",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "KAI"
+  "resourceType": "MedicationDispense",
+  "id": "jp-medicationdispense-injection-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationDispense_Injection"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationdispense-injection-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationdispense-injection.html\">JP Core MedicationDispense Injection Profile</a></p></div><p><b>identifier</b>: id: 1234567890, id: 1, id: 1</p><p><b>status</b>: completed</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: <a name=\"jp-medicationdispense-injection-medication-example-1\"> </a></p><blockquote><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationdispense-injection-medication-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><h3>Ingredients</h3><table class=\"grid\"><tr><td>-</td><td><b>Extension</b></td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td>*</td><td></td><td>ホリゾン注射液１０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#100558502)</span></td><td>1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></td></tr></table></blockquote><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><h3>Performers</h3><table class=\"grid\"><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Packager <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-medicationdispense-performer-function.html\">MedicationDispense Performer Function Codes</a>#packager)</span></td><td><a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1</a> \" 東京\"</td></tr></table><p><b>quantity</b>: 2 mL<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code mL = 'mL')</span></p><p><b>whenPrepared</b>: 2021-10-07 10:47:19+0900</p><p><b>whenHandedOver</b>: 2021-10-07 10:55:23+0900</p><p><b>destination</b>: <a href=\"Location-jp-location-example-ward.html\">Location/jp-location-example-ward</a> \"09A病棟 021病室 4ベッド\"</p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "jp-medicationdispense-injection-medication-example-1",
+      "meta": {
+        "profile": [
+          "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+        ]
+      },
+      "status": "active",
+      "ingredient": [
+        {
+          "extension": [
+            {
+              "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo",
+              "valueInteger": 1
+            }
+          ],
+          "itemCodeableConcept": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.74",
+                "code": "100558502",
+                "display": "ホリゾン注射液１０ｍｇ"
+              }
+            ]
+          },
+          "strength": {
+            "extension": [
+              {
+                "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_IngredientStrength_StrengthType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "urn:oid:1.2.392.100495.20.2.22",
+                      "code": "1",
+                      "display": "製剤量"
                     }
+                  ]
                 }
-            }]
-        },
-        {
-            "resourceType": "BodyStructure",
-            "id": "bodystructure1",
-            "location": {
-                "coding": [{
-                    "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
-                    "code": "ARM",
-                    "display": "腕"
-                }]
+              }
+            ],
+            "numerator": {
+              "value": 1,
+              "unit": "アンプル",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "AMP"
             },
-            "locationQualifier": [{
-                "coding": [{
-                    "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
-                    "code": "L",
-                    "display": "左"
-                }]
-            }],
-            "patient": {
-                "reference": "urn:uuid:79965040-5c95-4ce5-b8f7-efe606c364b4",
-                "type": "Patient"
+            "denominator": {
+              "value": 1,
+              "unit": "回",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "KAI"
             }
-        },
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "BodyStructure",
+      "id": "jp-medicationdispense-injection-bodystructure-example-1",
+      "location": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
+            "code": "ARM",
+            "display": "Arm"
+          }
+        ]
+      },
+      "locationQualifier": [
         {
-            "resourceType": "Device",
-            "id": "device1",
-            "type": {
-                "coding": [{
-                    "system": "http://jpfhir.jp/medication/99ILL",
-                    "code": "01",
-                    "display": "シリンジ"
-                }]
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
+              "code": "L",
+              "display": "Left"
             }
+          ]
         }
-    ],
-    "identifier": [{
-            "system": "urn:oid:1.2.392.100495.20.3.11",
-            "value": "123456789012345"
-        },
+      ],
+      "patient": {
+        "reference": "Patient/jp-patient-example-1"
+      }
+    },
+    {
+      "resourceType": "Device",
+      "id": "jp-medicationdispense-injection-device-example-1",
+      "type": {
+        "coding": [
+          {
+            "system": "http://jpfhir.jp/medication/99ILL",
+            "code": "01",
+            "display": "シリンジ"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://www.sample.com/fhir/medication-dispense",
+      "value": "1234567890"
+    },
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.81",
+      "value": "1"
+    },
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.82",
+      "value": "1"
+    }
+  ],
+  "status": "completed",
+  "category": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
+        "code": "I",
+        "display": "Inpatient Order"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "#jp-medicationdispense-injection-medication-example-1"
+  },
+  "subject": {
+    "reference": "Patient/jp-patient-example-1"
+  },
+  "performer": [
+    {
+      "function": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function",
+            "code": "packager",
+            "display": "Packager"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/jp-practionner-example-female-1"
+      }
+    }
+  ],
+  "quantity": {
+    "value": 2,
+    "unit": "mL",
+    "system": "http://unitsofmeasure.org",
+    "code": "mL"
+  },
+  "whenPrepared": "2021-10-07T10:47:19+09:00",
+  "whenHandedOver": "2021-10-07T10:55:23+09:00",
+  "destination": {
+    "reference": "Location/jp-location-example-ward"
+  },
+  "dosageInstruction": [
+    {
+      "extension": [
         {
-            "system": "urn:oid:1.2.392.100495.20.3.81",
-            "value": "123456789012345_01_001"
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Device",
+          "valueReference": {
+            "reference": "#jp-medicationdispense-injection-device-example-1",
+            "type": "Device"
+          }
         }
-    ],
-    "status": "active",
-    "intent": "order",
-    "category": [{
-            "coding": [{
-                "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
-                "code": "I",
-                "display": "入院患者オーダ"
-            }]
-        },
+      ],
+      "text": "ワンショット 静脈注射 静脈内",
+      "additionalInstruction": [
         {
-            "coding": [{
-                "system": "http://jpfhir.jp/Common/CodeSystem/merit9-category",
-                "code": "IHP",
-                "display": "入院処方"
-            }]
-        },
-        {
-            "coding": [{
-                "system": "http://jpfhir.jp/Common/CodeSystem/JHSI0001",
-                "code": "FTP",
-                "display": "定時処方"
-            }]
+          "coding": [
+            {
+              "system": "urn:oid:1.2.392.200250.2.2.20.45",
+              "code": "1",
+              "display": "ワンショット"
+            }
+          ]
         }
-    ],
-    "medicationReference": {
-        "reference": "#medication1",
-        "type": "Medication"
-    },
-    "subject": {
-        "reference": "urn:uuid:79965040-5c95-4ce5-b8f7-efe606c364b4",
-        "type": "Patient"
-    },
-    "authoredOn": "2016-07-01",
-    "requester": {
-        "reference": "urn:uuid:b598aedf-28fb-406a-b38e-250d3e92ac60",
-        "type": "PractitionerRole"
-    },
-    "insurance": [{
-        "reference": "urn:uuid:df0ebf6d-e527-49d4-bce2-0885045a7afd",
-        "type": "Coverage"
-    }],
-    "dosageInstruction": [{
-        "extension": [{
-            "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Device",
+      ],
+      "timing": {
+        "repeat": {
+          "boundsPeriod": {
+            "start": "2016-07-01T10:00:00+09:00"
+          }
+        }
+      },
+      "site": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
             "valueReference": {
-                "reference": "#device1",
-                "type": "Device"
+              "reference": "#jp-medicationdispense-injection-bodystructure-example-1",
+              "type": "BodyStructure"
             }
-        }],
-        "additionalInstruction": [{
-            "coding": [{
-                "system": "urn:oid:1.2.392.200250.2.2.20.45",
-                "code": "1",
-                "display": "ワンショット"
-            }]
-        }],
-        "timing": {
-            "repeat": {
-                "boundsPeriod": {
-                    "start": "2016-07-01T10:00:00+09:00"
-                }
-            }
-        },
-        "site": {
-            "extension": [{
-                "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
-                "valueReference": {
-                    "reference": "#bodystructure1",
-                    "type": "BodyStructure"
-                }
-            }]
-        },
-        "route": {
-            "coding": [{
-                "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
-                "code": "IV",
-                "display": "静脈内"
-            }]
-        },
-        "method": {
-            "coding": [{
-                "system": "urn:oid:1.2.392.200250.2.2.20.40",
-                "code": "30",
-                "display": "静脈注射"
-            }]
-        },
-        "doseAndRate": [{
-            "doseQuantity": {
-                "value": 2.0,
-                "unit": "mL",
-                "system": "http://unitsofmeasure.org",
-                "code": "mL"
-            }
-        }]
-    }]
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
+            "code": "IV",
+            "display": "静脈内"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.200250.2.2.20.40",
+            "code": "30",
+            "display": "静脈注射"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "doseQuantity": {
+            "value": 2,
+            "unit": "mL",
+            "system": "http://unitsofmeasure.org",
+            "code": "mL"
+          }
+        }
+      ]
+    }
+  ]
 }
 ```
-
-</div>
-</details>
 
 
 ## 注意事項
@@ -482,15 +533,21 @@ dosageInstruction.doseAndRate.doseQuantity要素には、情報が得られる�
 "contained": [
   {
     "resourceType": "Medication",
-    "id": "medication",
+    "id": "jp-medicationrequest-injection-medication-example-2",
+    "meta": {
+      "profile": [
+        "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+      ]
+    },
+    "status": "active",
     "ingredient": [
       {
         "itemCodeableConcept": {
           "coding": [
             {
+              "system": "urn:oid:1.2.392.100495.20.2.74",
               "code": "107750602",
-              "display": "ソリタ－Ｔ３号輸液５００ｍＬ",
-              "system": "urn:oid:1.2.392.200119.4.403.1"
+              "display": "ソリタ－Ｔ３号輸液５００ｍＬ"
             }
           ]
         },
@@ -508,13 +565,14 @@ dosageInstruction.doseAndRate.doseQuantity要素には、情報が得られる�
             "code": "KAI"
           }
         }
-      }, {
+      },
+      {
         "itemCodeableConcept": {
           "coding": [
             {
+              "system": "urn:oid:1.2.392.100495.20.2.74",
               "code": "108010001",
-              "display": "アドナ注（静脈用）50mg／10mL",
-              "system": "urn:oid:1.2.392.200119.4.403.1"
+              "display": "アドナ注（静脈用）５０ｍｇ"
             }
           ]
         },
@@ -534,10 +592,11 @@ dosageInstruction.doseAndRate.doseQuantity要素には、情報が得られる�
         }
       }
     ]
-  },
+  }
 ],
+...
 "medicationReference": {
-  "reference": "#medication"
+  "reference": "#jp-medicationrequest-injection-medication-example-2"
 },
 ```
 

--- a/input/intro-notes/StructureDefinition-jp-medicationdispense-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationdispense-notes.md
@@ -247,182 +247,183 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
+下記の内容の処方に従って調剤する例をFHIRで表現する場合のサンプルを示す。
 ```
 Rp1 ムコダイン錠２５０ｍｇ１錠（  １日３錠)
 　　１日３回朝昼夕食後３日分
 ```
 
-```JSON
+```json
 {
-    "resourceType": "MedicationDispense",
-    "extension": [
-        {
-            "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
-            "valueDuration": {
-                "value": 3,
-                "unit": "日",
-                "system": "http://unitsofmeasure.org",
-                "code": "d"
-            }
-        }
-    ],
-    "identifier": [ 
-        {
-            "system": "http://www.sample.com/fhir/medication-dispense",
-            "value": "1234567890"
-        },
-        {
-            "system": "urn:oid:1.2.392.100495.20.3.81",
-            "value": "1"
-        },
-        {
-            "system": "urn:oid:1.2.392.100495.20.3.82",
-            "value": "1"
-        } 
-    ],
-    "status" : "completed",
-    "category" : {
-        "coding":  [
-            {
-                "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
-                "code": "I",
-                "display": "入院オーダ"
-            }
-        ]
+  "resourceType": "MedicationDispense",
+  "id": "jp-medicationdispense-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationDispense"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationdispense-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationdispense.html\">JP Core MedicationDispense Profile</a></p></div><p><b>identifier</b>: id: 1234567890, id: 1, id: 1</p><p><b>status</b>: completed</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span></p><p><b>medication</b>: ムコダイン錠２５０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#103835401)</span></p><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><h3>Performers</h3><table class=\"grid\"><tr><td>-</td><td><b>Function</b></td><td><b>Actor</b></td></tr><tr><td>*</td><td>Packager <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-medicationdispense-performer-function.html\">MedicationDispense Performer Function Codes</a>#packager)</span></td><td><a href=\"Practitioner-jp-practionner-example-male-1.html\">Practitioner/jp-practionner-example-male-1</a> \" 大阪\"</td></tr></table><p><b>quantity</b>: 9 錠<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code TAB = 'TAB')</span></p><p><b>whenPrepared</b>: 2021-10-07 10:47:19+0900</p><p><b>whenHandedOver</b>: 2021-10-07 10:55:23+0900</p><p><b>destination</b>: <a href=\"Location-jp-location-example-ward.html\">Location/jp-location-example-ward</a> \"09A病棟 021病室 4ベッド\"</p><p><b>note</b>: 後発品へ変更可能か依頼医のＡ医師に確認したところ、患者の希望により不可との回答あり。</p><h3>Substitutions</h3><table class=\"grid\"><tr><td>-</td><td><b>WasSubstituted</b></td><td><b>Type</b></td><td><b>Reason</b></td></tr><tr><td>*</td><td>true</td><td>generic composition <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-substanceAdminSubstitution.html\">Substance Admin Substitution</a>#G)</span></td><td>regulatory requirement <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v3-ActReason.html\">ActReason</a>#RR)</span></td></tr></table></div>"
+  },
+  "identifier": [
+    {
+      "system": "http://www.sample.com/fhir/medication-dispense",
+      "value": "1234567890"
     },
-    "medicationCodeableConcept": {
-        "coding":  [
-            {
-                "system": "urn:oid:1.2.392.200119.4.403.1",
-                "code": "103835401",
-                "display": "ムコダイン錠２５０ｍｇ"
-            }
-        ]
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.81",
+      "value": "1"
     },
-    "subject" : {
-        "reference" : "Patient/1234567890"
-    },
-    "performer" : [
-        {
-            "function" : {
-                "coding" : [
-                    {
-                        "code" : "packager",
-                        "system" : "http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function",
-                        "display" : "Packager"
-                    }
-                ]
-            },
-            "actor" : {
-                "reference" : "Practitioner/01234567"
-            }
-        }
-    ],
-    "quantity": {
-        "value": 9,
-        "unit": "錠",
-        "system": "urn:oid:1.2.392.100495.20.2.101",
-        "code": "TAB"
-    },
-    "whenPrepared" : "2021-10-07T10:47:19+09:00",
-    "whenHandedOver" : "2021-10-07T10:55:23+09:00",
-    "destination" : {
-        "reference" : "Location/12A"
-    },
-    "note" : [
-        {
-            "text" : "後発品へ変更可能か依頼医のＡ医師に確認したところ、患者の希望により不可との回答あり。"
-        }
-    ],
-    "dosageInstruction":  [
-        {
-            "timing": {
-                "code":  {
-             "coding":  [
-                 {
-                     "system": "urn:oid:1.2.392.200250.2.2.20.20",
-                     "code": "1013044400000000",
-                     "display": "内服・経口・１日３回朝昼夕食後"
-                 }
-                    ]
-         }
-            },
-            "route": {
-                "coding": [
-                    {
-                        "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
-                        "code": "PO",
-                        "display": "口"
-                    }
-                ]
-            },
-            "method": {
-                "coding": [
-                    {
-                        "system": "urn:oid:1.2.392.200250.2.2.20.40",
-                        "code": "10",
-                        "display": "経口"
-                    }
-                ]
-            },
-            "doseAndRate":  [
-                {
-                    "type": {
-                        "coding":  [
-                            {
-                                "system": "urn:oid:1.2.392.100495.20.2.22",
-                                "code": "1",
-                                "display": "製剤量"
-                            }
-                        ]
-                    },
-                    "doseQuantity": {
-                        "value": 1,
-                        "unit": "錠",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "TAB"
-                    },
-                    "rateRatio": {
-                        "numerator": {
-                            "value": 3,
-                            "unit": "錠",
-                            "system": "urn:oid:1.2.392.100495.20.2.101",
-                            "code": "TAB"
-                        },
-                        "denominator": {
-                            "value": 1,
-                            "unit": "日",
-                            "system": "http://unitsofmeasure.org",
-                            "code": "d"
-                        }
-                    }
-                }
-            ]
-        }
-    ],
-    "substitution" : {
-        "wasSubstituted" : true,
-        "type" : {
-            "coding" : [
-                {
-                    "code" : "G",
-                    "system" : "http://terminology.hl7.org/CodeSystem/v3-substanceAdminSubstitution",
-                    "display" : "generic composition"
-                }
-            ]
-        },
-        "reason": [
-            {
-                "coding" : [
-                    {
-                        "code" : "RR",
-                        "system" : "http://terminology.hl7.org/CodeSystem/v3-ActReason",
-                        "display" : "regulatory requirement"
-                    }
-                ]
-            }
-        ]
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.82",
+      "value": "1"
     }
+  ],
+  "status": "completed",
+  "category": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
+        "code": "I",
+        "display": "Inpatient Order"
+      }
+    ]
+  },
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.392.200119.4.403.1",
+        "code": "103835401",
+        "display": "ムコダイン錠２５０ｍｇ"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/jp-patient-example-1"
+  },
+  "performer": [
+    {
+      "function": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/medicationdispense-performer-function",
+            "code": "packager",
+            "display": "Packager"
+          }
+        ]
+      },
+      "actor": {
+        "reference": "Practitioner/jp-practionner-example-male-1"
+      }
+    }
+  ],
+  "quantity": {
+    "value": 9,
+    "unit": "錠",
+    "system": "urn:oid:1.2.392.100495.20.2.101",
+    "code": "TAB"
+  },
+  "whenPrepared": "2021-10-07T10:47:19+09:00",
+  "whenHandedOver": "2021-10-07T10:55:23+09:00",
+  "destination": {
+    "reference": "Location/jp-location-example-ward"
+  },
+  "note": [
+    {
+      "text": "後発品へ変更可能か依頼医のＡ医師に確認したところ、患者の希望により不可との回答あり。"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "text": "内服・経口・１日３回朝昼夕食後",
+      "timing": {
+        "code": {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.392.200250.2.2.20.20",
+              "code": "1013044400000000",
+              "display": "内服・経口・１日３回朝昼夕食後"
+            }
+          ]
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
+            "code": "PO",
+            "display": "口"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.200250.2.2.20.40",
+            "code": "10",
+            "display": "経口"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.22",
+                "code": "1",
+                "display": "製剤量"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "錠",
+            "system": "urn:oid:1.2.392.100495.20.2.101",
+            "code": "TAB"
+          },
+          "rateRatio": {
+            "numerator": {
+              "value": 3,
+              "unit": "錠",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "TAB"
+            },
+            "denominator": {
+              "value": 1,
+              "unit": "日",
+              "system": "http://unitsofmeasure.org",
+              "code": "d"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "substitution": {
+    "wasSubstituted": true,
+    "type": {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-substanceAdminSubstitution",
+          "code": "G",
+          "display": "generic composition"
+        }
+      ]
+    },
+    "reason": [
+      {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
+            "code": "RR",
+            "display": "regulatory requirement"
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 

--- a/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
@@ -305,202 +305,258 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
-
-#### 処方例１
-<details>
-<summary><b>ホリゾン注射液１０ｍｇ１アンプルを左腕に静脈注射(クリックで展開)</b></summary>
-<div>
-
+ホリゾン注射液１０ｍｇ１アンプルを左腕に静脈注射する処方例をFHIRで表現する場合のサンプルを示す。
 ```json
 {
-    "resourceType": "MedicationRequest",
-    "contained": [{
-            "resourceType": "Medication",
-            "id": "medication1",
-            "ingredient": [{
-                "extension": [{
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo",
-                    "valueInteger": 1
-                }],
-                "itemCodeableConcept": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.100495.20.2.74",
-                        "code": "100558502",
-                        "display": "ホリゾン注射液１０ｍｇ"
-                    }]
-                },
-                "strength": {
-                    "extension": [{
-                        "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Strength_StrengthType",
-                        "valueCodeableConcept": {
-                            "coding": [{
-                                "system": "urn:oid:1.2.392.100495.20.2.22",
-                                "code": "1",
-                                "display": "製剤量"
-                            }]
-                        }
-                    }],
-                    "numerator": {
-                        "value": 1,
-                        "unit": "アンプル",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "AMP"
-                    },
-                    "denominator": {
-                        "value": 1,
-                        "unit": "回",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "KAI"
+  "resourceType": "MedicationRequest",
+  "id": "jp-medicationrequest-injection-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest_Injection"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationrequest-injection-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationrequest-injection.html\">JP Core MedicationRequest Injection Profile</a></p></div><p><b>identifier</b>: id: 1, id: 2, id: 1234567890.1.1</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>category</b>: Inpatient Order <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-v2-0482.html\">orderType</a>#I)</span>, 入院処方 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (merit9-category#IHP)</span>, 定時処方 <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (JHSI0001#FTP)</span></p><p><b>medication</b>: <a name=\"jp-medicationrequest-injection-medication-example-1\"> </a></p><blockquote><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationrequest-injection-medication-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medication.html\">JP Core Medication Profile</a></p></div><p><b>status</b>: active</p><h3>Ingredients</h3><table class=\"grid\"><tr><td>-</td><td><b>Extension</b></td><td><b>Item[x]</b></td><td><b>Strength</b></td></tr><tr><td>*</td><td></td><td>ホリゾン注射液１０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#100558502)</span></td><td>1 アンプル<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code AMP = 'AMP')</span>/1 回<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code KAI = 'KAI')</span></td></tr></table></blockquote><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>authoredOn</b>: 2016-07-01 09:28:17+0900</p><p><b>requester</b>: <a href=\"Practitioner-jp-practionner-example-female-1.html\">Practitioner/jp-practionner-example-female-1</a> \" 東京\"</p><p><b>insurance</b>: <a href=\"Coverage-jp-coverage-example-1.html\">Coverage/jp-coverage-example-1</a></p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Medication",
+      "id": "jp-medicationrequest-injection-medication-example-1",
+      "meta": {
+        "profile": [
+          "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Medication"
+        ]
+      },
+      "status": "active",
+      "ingredient": [
+        {
+          "extension": [
+            {
+              "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo",
+              "valueInteger": 1
+            }
+          ],
+          "itemCodeableConcept": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.74",
+                "code": "100558502",
+                "display": "ホリゾン注射液１０ｍｇ"
+              }
+            ]
+          },
+          "strength": {
+            "extension": [
+              {
+                "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_IngredientStrength_StrengthType",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "urn:oid:1.2.392.100495.20.2.22",
+                      "code": "1",
+                      "display": "製剤量"
                     }
+                  ]
                 }
-            }]
-        },
-        {
-            "resourceType": "BodyStructure",
-            "id": "bodystructure1",
-            "location": {
-                "coding": [{
-                    "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
-                    "code": "ARM",
-                    "display": "腕"
-                }]
+              }
+            ],
+            "numerator": {
+              "value": 1,
+              "unit": "アンプル",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "AMP"
             },
-            "locationQualifier": [{
-                "coding": [{
-                    "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
-                    "code": "L",
-                    "display": "左"
-                }]
-            }],
-            "patient": {
-                "reference": "urn:uuid:79965040-5c95-4ce5-b8f7-efe606c364b4",
-                "type": "Patient"
+            "denominator": {
+              "value": 1,
+              "unit": "回",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "KAI"
             }
-        },
+          }
+        }
+      ]
+    },
+    {
+      "resourceType": "BodyStructure",
+      "id": "jp-medicationrequest-injection-bodystructure-example-1",
+      "location": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0550",
+            "code": "ARM",
+            "display": "Arm"
+          }
+        ]
+      },
+      "locationQualifier": [
         {
-            "resourceType": "Device",
-            "id": "device1",
-            "type": {
-                "coding": [{
-                    "system": "http://jpfhir.jp/medication/99ILL",
-                    "code": "01",
-                    "display": "シリンジ"
-                }]
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0495",
+              "code": "L",
+              "display": "Left"
             }
+          ]
         }
-    ],
-    "identifier": [{
-            "system": "urn:oid:1.2.392.100495.20.3.11",
-            "value": "123456789012345"
-        },
+      ],
+      "patient": {
+        "reference": "Patient/jp-patient-example-1"
+      }
+    },
+    {
+      "resourceType": "Device",
+      "id": "jp-medicationrequest-injection-device-example-1",
+      "type": {
+        "coding": [
+          {
+            "system": "http://jpfhir.jp/medication/99ILL",
+            "code": "01",
+            "display": "シリンジ"
+          }
+        ]
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.81",
+      "value": "1"
+    },
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.82",
+      "value": "2"
+    },
+    {
+      "system": "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier",
+      "value": "1234567890.1.1"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "category": [
+    {
+      "coding": [
         {
-            "system": "urn:oid:1.2.392.100495.20.3.81",
-            "value": "123456789012345_01_001"
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
+          "code": "I",
+          "display": "Inpatient Order"
         }
-    ],
-    "status": "active",
-    "intent": "order",
-    "category": [{
-            "coding": [{
-                "system": "http://terminology.hl7.org/CodeSystem/v2-0482",
-                "code": "I",
-                "display": "入院患者オーダ"
-            }]
-        },
+      ]
+    },
+    {
+      "coding": [
         {
-            "coding": [{
-                "system": "http://jpfhir.jp/Common/CodeSystem/merit9-category",
-                "code": "IHP",
-                "display": "入院処方"
-            }]
-        },
-        {
-            "coding": [{
-                "system": "http://jpfhir.jp/Common/CodeSystem/JHSI0001",
-                "code": "FTP",
-                "display": "定時処方"
-            }]
+          "system": "http://jpfhir.jp/Common/CodeSystem/merit9-category",
+          "code": "IHP",
+          "display": "入院処方"
         }
-    ],
-    "medicationReference": {
-        "reference": "#medication1",
-        "type": "Medication"
+      ]
     },
-    "subject": {
-        "reference": "urn:uuid:79965040-5c95-4ce5-b8f7-efe606c364b4",
-        "type": "Patient"
-    },
-    "authoredOn": "2016-07-01",
-    "requester": {
-        "reference": "urn:uuid:b598aedf-28fb-406a-b38e-250d3e92ac60",
-        "type": "PractitionerRole"
-    },
-    "insurance": [{
-        "reference": "urn:uuid:df0ebf6d-e527-49d4-bce2-0885045a7afd",
-        "type": "Coverage"
-    }],
-    "dosageInstruction": [{
-        "extension": [{
-            "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Device",
+    {
+      "coding": [
+        {
+          "system": "http://jpfhir.jp/Common/CodeSystem/JHSI0001",
+          "code": "FTP",
+          "display": "定時処方"
+        }
+      ]
+    }
+  ],
+  "medicationReference": {
+    "reference": "#jp-medicationrequest-injection-medication-example-1"
+  },
+  "subject": {
+    "reference": "Patient/jp-patient-example-1"
+  },
+  "authoredOn": "2016-07-01T09:28:17+09:00",
+  "requester": {
+    "reference": "Practitioner/jp-practionner-example-female-1"
+  },
+  "insurance": [
+    {
+      "reference": "Coverage/jp-coverage-example-1"
+    }
+  ],
+  "dosageInstruction": [
+    {
+      "extension": [
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Device",
+          "valueReference": {
+            "reference": "#jp-medicationrequest-injection-device-example-1"
+          }
+        }
+      ],
+      "text": "ワンショット 静脈注射 静脈内 左腕",
+      "additionalInstruction": [
+        {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.392.200250.2.2.20.22",
+              "code": "1",
+              "display": "ワンショット"
+            }
+          ]
+        }
+      ],
+      "timing": {
+        "repeat": {
+          "boundsPeriod": {
+            "start": "2016-07-01T10:00:00+09:00"
+          }
+        }
+      },
+      "site": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
             "valueReference": {
-                "reference": "#device1",
-                "type": "Device"
+              "reference": "#jp-medicationrequest-injection-bodystructure-example-1"
             }
-        }],
-        "additionalInstruction": [{
-            "coding": [{
-                "system": "urn:oid:1.2.392.200250.2.2.20.45",
-                "code": "1",
-                "display": "ワンショット"
-            }]
-        }],
-        "timing": {
-            "repeat": {
-                "boundsPeriod": {
-                    "start": "2016-07-01T10:00:00+09:00"
-                }
-            }
-        },
-        "site": {
-            "extension": [{
-                "url": "http://hl7.org/fhir/StructureDefinition/bodySite",
-                "valueReference": {
-                    "reference": "#bodystructure1",
-                    "type": "BodyStructure"
-                }
-            }]
-        },
-        "route": {
-            "coding": [{
-                "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
-                "code": "IV",
-                "display": "静脈内"
-            }]
-        },
-        "method": {
-            "coding": [{
-                "system": "urn:oid:1.2.392.200250.2.2.20.40",
-                "code": "30",
-                "display": "静脈注射"
-            }]
-        },
-        "doseAndRate": [{
-            "doseQuantity": {
-                "value": 2.0,
-                "unit": "mL",
-                "system": "http://unitsofmeasure.org",
-                "code": "mL"
-            }
-        }]
-    }]
+          }
+        ]
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://jpfhir.jp/fhir/ePrescription/CodeSystem/route-codes",
+            "code": "IV",
+            "display": "静脈内"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.200250.2.2.20.40",
+            "code": "30",
+            "display": "静脈注射"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.22",
+                "code": "1"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 2,
+            "unit": "mL",
+            "system": "urn:oid:1.2.392.100495.20.2.101",
+            "code": "mL"
+          }
+        }
+      ]
+    }
+  ]
 }
 ```
-
-</div>
-</details>
-
-#### 処方例２
-[処方例２](https://simplifier.net/jpcore/a97c3c13-ac3c-412a-a9fb-2237a17138b8/~json)
 
 ## 注意事項
 

--- a/input/intro-notes/StructureDefinition-jp-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationrequest-notes.md
@@ -284,264 +284,304 @@ HTTP/1.1 200 OK
 ```
 
 ### サンプル
-. 処方例1{{link:jp_medication_example_1.xml}}
-1. 一日量処方例(JSON)
-1. 不均等処方の一日量表現(JSON)
-1. 分割処方箋(TBD)
-
-#### 処方箋メッセージ作成例
-具体的な内服処方箋の作成例について、上記のサンプルのそれぞれについて解説する。
-
-##### 処方例１
-この処方箋例では[JAHIS処方データ交換規約 Ver.3.0C](https://www.jahis.jp/standard/detail/id=564)98ページに記載されている下記の処方例をFHIRで表現する場合について解説する。
+[JAHIS処方データ交換規約 Ver.3.0C](https://www.jahis.jp/standard/detail/id=564)98ページに記載されている下記の処方例をFHIRで表現する場合のサンプルを示す。
 ```
-Rp1 ムコダイン錠２５０ｍｇ１錠（  １日３錠)
-　パンスポリンＴ錠１００１００ｍｇ２錠（  １日６錠）
+Rp1 ムコダイン錠２５０ｍｇ　１錠（  １日３錠)
+　パンスポリンＴ錠１００　１００ｍｇ　２錠（  １日６錠）
 　　１日３回朝昼夕食後３日分
 ```
 
 HL7ではFHIRに限らず、Ver 2以降全て欧米で使用されている1回量処方で記述されることにまず注意すべきである。（1日量処方への対応については後述する。）
 
-処方箋の上記部分をFHIR R4で記述する場合以下のようになる。
-<details>
-<summary><b>FHIRでの処方例一部抜粋(クリックで展開)</b></summary>
-<div>
+処方箋の上記部分をFHIR R4で記述する場合、薬剤ごとにそれぞれ以下のようになる。
 
+#### ムコダイン錠２５０ｍｇ　１錠
 ```json
 {
-    "resource": {
-        "resourceType": "MedicationRequest",
-        "identifier": [{
-                "system": "http://sample.com/medication",
-                "value": "1234567890.1.1"
-            },
-            {
-                "system": "urn:oid:1.2.392.100495.20.3.81",
-                "value": "1"
-            },
-            {
-                "system": "urn:oid:1.2.392.100495.20.3.82",
-                "value": "1"
-            }
-        ],
-        "intent": "order",
-        "status": "active",
-        "medicationCodeableConcept": {
-            "coding": [{
-                "system": "urn:oid:1.2.392.200119.4.403.1",
-                "code": "103835401",
-                "display": "ムコダイン錠２５０ｍｇ"
-            }]
-        },
-        "subject": {
-            "reference": "Patient/1234567890"
-        },
-        "dosageInstruction": [{
-            "extension": [{
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse",
-                    "valuePeriod": {
-                        "start": "2020-04-01"
-                    }
-                },
-                {
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
-                    "valueDuration": {
-                        "value": 3,
-                        "unit": "日",
-                        "system": "http://unitsofmeasure.org",
-                        "code": "d"
-                    }
-                }
-            ],
-            "timing": {
-                "code": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.200250.2.2.20.20",
-                        "code": "1013044400000000",
-                        "display": "内服・経口・１日３回朝昼夕食後"
-                    }]
-                }
-            },
-            "route": {
-                "coding": [{
-                    "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
-                    "code": "PO",
-                    "display": "口"
-                }]
-            },
-            "method": {
-                "coding": [{
-                    "system": "urn:oid:1.2.392.200250.2.2.20.40",
-                    "code": "10",
-                    "display": "経口"
-                }]
-            },
-            "doseAndRate": [{
-                "type": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.100495.20.2.22",
-                        "code": "1",
-                        "display": "製剤量"
-                    }]
-                },
-                "doseQuantity": {
-                    "value": 1,
-                    "unit": "錠",
-                    "system": "urn:oid:1.2.392.100495.20.2.101",
-                    "code": "TAB"
-                },
-                "rateRatio": {
-                    "numerator": {
-                        "value": 3,
-                        "unit": "錠",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "TAB"
-                    },
-                    "denominator": {
-                        "value": 1,
-                        "unit": "日",
-                        "system": "http://unitsofmeasure.org",
-                        "code": "d"
-                    }
-                }
-            }]
-        }],
-        "dispenseRequest": {
-            "quantity": {
-                "value": 9,
-                "unit": "錠",
-                "system": "urn:oid:1.2.392.100495.20.2.101",
-                "code": "TAB"
-            },
-            "expectedSupplyDuration": {
-                "value": 3,
-                "unit": "日",
-                "system": "http://unitsofmeasure.org",
-                "code": "d"
-            }
-        }
+  "resourceType": "MedicationRequest",
+  "id": "jp-medicationrequest-example-1",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationrequest-example-1\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationrequest.html\">JP Core MedicationRequest Profile</a></p></div><p><b>identifier</b>: id: 1, id: 1, id: 1234567890.1.1</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: ムコダイン錠２５０ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#103835401)</span></p><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>authoredOn</b>: 2020-04-01 12:28:17+0900</p><blockquote><p><b>dispenseRequest</b></p><p><b>quantity</b>: 9 錠<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code TAB = 'TAB')</span></p></blockquote></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.81",
+      "value": "1"
+    },
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.82",
+      "value": "1"
+    },
+    {
+      "system": "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier",
+      "value": "1234567890.1.1"
     }
-}, {
-    "resource": {
-        "resourceType": "MedicationRequest",
-        "identifier": [{
-                "system": "http://sample.com/medication",
-                "value": "1234567890.1.2"
-            },
-            {
-                "system": "urn:oid:1.2.392.100495.20.3.81",
-                "value": "1"
-            },
-            {
-                "system": "urn:oid:1.2.392.100495.20.3.82",
-                "value": "2"
-            }
-        ],
-        "intent": "order",
-        "status": "active",
-        "medicationCodeableConcept": {
-            "coding": [{
-                "system": "urn:oid:1.2.392.200119.4.403.1",
-                "code": "110626901",
-                "display": "パンスポリンＴ錠１００ １００ｍｇ"
-            }]
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.392.200119.4.403.1",
+        "code": "103835401",
+        "display": "ムコダイン錠２５０ｍｇ"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/jp-patient-example-1"
+  },
+  "authoredOn": "2020-04-01T12:28:17+09:00",
+  "dosageInstruction": [
+    {
+      "extension": [
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse",
+          "valuePeriod": {
+            "start": "2020-04-01"
+          }
         },
-        "subject": {
-            "reference": "Patient/1234567890"
-        },
-        "dosageInstruction": [{
-            "extension": [{
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse",
-                    "valuePeriod": {
-                        "start": "2020-04-01"
-                    }
-                },
-                {
-                    "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
-                    "valueDuration": {
-                        "value": 3,
-                        "unit": "日",
-                        "system": "http://unitsofmeasure.org",
-                        "code": "d"
-                    }
-                }
-            ],
-            "timing": {
-                "code": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.200250.2.2.20.20",
-                        "code": "1013044400000000",
-                        "display": "内服・経口・１日３回朝昼夕食後"
-                    }]
-                }
-            },
-            "route": {
-                "coding": [{
-                    "system": "urn:oid:2.16.840.1.113883.3.1937.777.10.5.162",
-                    "code": "PO",
-                    "display": "口"
-                }]
-            },
-            "method": {
-                "coding": [{
-                    "system": "urn:oid:1.2.392.200250.2.2.20.40",
-                    "code": "10",
-                    "display": "経口"
-                }]
-            },
-            "doseAndRate": [{
-                "type": {
-                    "coding": [{
-                        "system": "urn:oid:1.2.392.100495.20.2.22",
-                        "code": "1",
-                        "display": "製剤量"
-                    }]
-                },
-                "doseQuantity": {
-                    "value": 2,
-                    "unit": "錠",
-                    "system": "urn:oid:1.2.392.100495.20.2.101",
-                    "code": "TAB"
-                },
-                "rateRatio": {
-                    "numerator": {
-                        "value": 6,
-                        "unit": "錠",
-                        "system": "urn:oid:1.2.392.100495.20.2.101",
-                        "code": "TAB"
-                    },
-                    "denominator": {
-                        "value": 1,
-                        "unit": "日",
-                        "system": "http://unitsofmeasure.org",
-                        "code": "d"
-                    }
-                }
-            }]
-        }],
-        "dispenseRequest": {
-            "quantity": {
-                "value": 18,
-                "unit": "錠",
-                "system": "urn:oid:1.2.392.100495.20.2.101",
-                "code": "TAB"
-            },
-            "expectedSupplyDuration": {
-                "value": 3,
-                "unit": "日",
-                "system": "http://unitsofmeasure.org",
-                "code": "d"
-            }
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
+          "valueDuration": {
+            "value": 3,
+            "unit": "日",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
         }
+      ],
+      "text": "内服・経口・１日３回朝昼夕食後",
+      "timing": {
+        "code": {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.392.200250.2.2.20.20",
+              "code": "1013044400000000",
+              "display": "内服・経口・１日３回朝昼夕食後"
+            }
+          ]
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://jpfhir.jp/fhir/ePrescription/CodeSystem/route-codes",
+            "code": "PO",
+            "display": "口"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.200250.2.2.20.40",
+            "code": "10",
+            "display": "経口"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.22",
+                "code": "1",
+                "display": "製剤量"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "錠",
+            "system": "urn:oid:1.2.392.100495.20.2.101",
+            "code": "TAB"
+          },
+          "rateRatio": {
+            "numerator": {
+              "value": 3,
+              "unit": "錠",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "TAB"
+            },
+            "denominator": {
+              "value": 1,
+              "unit": "日",
+              "system": "http://unitsofmeasure.org",
+              "code": "d"
+            }
+          }
+        }
+      ]
     }
+  ],
+  "dispenseRequest": {
+    "quantity": {
+      "value": 9,
+      "unit": "錠",
+      "system": "urn:oid:1.2.392.100495.20.2.101",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 3,
+      "unit": "日",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  }
 }
 ```
-</div>
-</details>
 
-### サンプル
-<!-- MedicationReqestのexampleではないため、一旦コメントアウト -->
- <!-- [JSONサンプル](templatejsonsample) -->
+#### パンスポリンＴ錠１００　１００ｍｇ　２錠
+```json
+{
+  "resourceType": "MedicationRequest",
+  "id": "jp-medicationrequest-example-2",
+  "meta": {
+    "profile": [
+      "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource \"jp-medicationrequest-example-2\" </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-jp-medicationrequest.html\">JP Core MedicationRequest Profile</a></p></div><p><b>identifier</b>: id: 2, id: 2, id: 1234567890.1.2</p><p><b>status</b>: active</p><p><b>intent</b>: order</p><p><b>medication</b>: パンスポリンＴ錠１００ １００ｍｇ <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (unknown#110626901)</span></p><p><b>subject</b>: <a href=\"Patient-jp-patient-example-1.html\">Patient/jp-patient-example-1</a> \" 山田\"</p><p><b>authoredOn</b>: 2020-04-01 12:28:17+0900</p><blockquote><p><b>dispenseRequest</b></p><p><b>quantity</b>: 18 錠<span style=\"background: LightGoldenRodYellow\"> (Details: urn:oid:1.2.392.100495.20.2.101 code TAB = 'TAB')</span></p></blockquote></div>"
+  },
+  "identifier": [
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.81",
+      "value": "2"
+    },
+    {
+      "system": "urn:oid:1.2.392.100495.20.3.82",
+      "value": "2"
+    },
+    {
+      "system": "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier",
+      "value": "1234567890.1.2"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "urn:oid:1.2.392.200119.4.403.1",
+        "code": "110626901",
+        "display": "パンスポリンＴ錠１００ １００ｍｇ"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/jp-patient-example-1"
+  },
+  "authoredOn": "2020-04-01T12:28:17+09:00",
+  "dosageInstruction": [
+    {
+      "extension": [
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse",
+          "valuePeriod": {
+            "start": "2020-04-01"
+          }
+        },
+        {
+          "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration",
+          "valueDuration": {
+            "value": 3,
+            "unit": "日",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          }
+        }
+      ],
+      "text": "内服・経口・１日３回朝昼夕食後",
+      "timing": {
+        "code": {
+          "coding": [
+            {
+              "system": "urn:oid:1.2.392.200250.2.2.20.20",
+              "code": "1013044400000000",
+              "display": "内服・経口・１日３回朝昼夕食後"
+            }
+          ]
+        }
+      },
+      "route": {
+        "coding": [
+          {
+            "system": "http://jpfhir.jp/fhir/ePrescription/CodeSystem/route-codes",
+            "code": "PO",
+            "display": "口"
+          }
+        ]
+      },
+      "method": {
+        "coding": [
+          {
+            "system": "urn:oid:1.2.392.200250.2.2.20.40",
+            "code": "10",
+            "display": "経口"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "urn:oid:1.2.392.100495.20.2.22",
+                "code": "1",
+                "display": "製剤量"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 2,
+            "unit": "錠",
+            "system": "urn:oid:1.2.392.100495.20.2.101",
+            "code": "TAB"
+          },
+          "rateRatio": {
+            "numerator": {
+              "value": 6,
+              "unit": "錠",
+              "system": "urn:oid:1.2.392.100495.20.2.101",
+              "code": "TAB"
+            },
+            "denominator": {
+              "value": 1,
+              "unit": "日",
+              "system": "http://unitsofmeasure.org",
+              "code": "d"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "dispenseRequest": {
+    "quantity": {
+      "value": 18,
+      "unit": "錠",
+      "system": "urn:oid:1.2.392.100495.20.2.101",
+      "code": "TAB"
+    },
+    "expectedSupplyDuration": {
+      "value": 3,
+      "unit": "日",
+      "system": "http://unitsofmeasure.org",
+      "code": "d"
+    }
+  }
+}
+```
  
 ## 注意事項
 
@@ -860,7 +900,6 @@ HL7 FHIRでは、処方箋の中で同一の用法を持つ剤グループ(RP)�
 
 #### １回用法の例
 朝食後に4錠、昼食後2錠、夕食後1錠、合計1日投与量7錠であることを1回用法で３つの剤グループで表現したインスタンスの例である。
-<details><summary>１回用法の例</summary><div>
 
 ```json
 {
@@ -998,7 +1037,10 @@ HL7 FHIRでは、処方箋の中で同一の用法を持つ剤グループ(RP)�
       }
     }
   }
-},
+}
+```
+
+json```
 {
   "fullUrl": "urn:uuid:c39d005e-22e0-7991-bca2-565bff406e10",
   "resource": {
@@ -1130,7 +1172,9 @@ HL7 FHIRでは、処方箋の中で同一の用法を持つ剤グループ(RP)�
       }
     }
   }
-},
+}
+```
+json```
 {
   "fullUrl": "urn:uuid:713d17e1-1e8b-dba1-95e2-763f179e805a",
   "resource": {
@@ -1264,15 +1308,13 @@ HL7 FHIRでは、処方箋の中で同一の用法を持つ剤グループ(RP)�
   }
 }
 ```
-</div></details>
 
 #### １日用法の例
 朝食後に4錠、昼食後2錠、夕食後1錠、合計1日投与量7錠であることを1日用法で表現したインスタンスの例である。
 １つのMedicationRequestリソースの1つのdosageInstruction要素を使用し、dosageInstruction.doseAndRate.rateRatio要素に、1日投与量のみを記載する。1回の投与量の情報をコードとして記述できる場合は、dosageInstruction.additionalInstruction要素に、1 日の服用回数分だけ繰り返し、JAMI補足用法コードを使用し記述する。コード化できない場合は、明細単位の備考としてテキストで記述する。
-<details><summary>１日用法の例</summary><div>
 
 ```json
-"resource": {
+{
   "resourceType": "MedicationRequest",
   "text": {
     "status": "generated",
@@ -1428,7 +1470,6 @@ HL7 FHIRでは、処方箋の中で同一の用法を持つ剤グループ(RP)�
   }
 }
 ```
-</div></details>
 
 ### 隔日指定投与の記述方法
 隔日指定投与は、連続して服用する日数と、その後の連続して休薬する日数を指定する用法である。


### PR DESCRIPTION
## 修正内容
・バリデーションでOKとなったサンプルインスタンスを実装ガイドに取り込む
・サンプルインスタンスを折り畳みの中に入れると表示が崩れるため、折り畳みを止める
・複数のインスタンスを１つにまとめるのをやめ、インスタンスごとに記述する

## 担当SWG
SWG5

## Merge依頼先
@skoba 

## レビュー観点
表示の崩れがないか

## 補足

