### PR TITLE
MedicationRequest.identifierのexample記法をindexからスライス名に変更した

### DIFF
--- a/input/fsh/examples/JP_MedicationRequest_Example.fsh
+++ b/input/fsh/examples/JP_MedicationRequest_Example.fsh
@@ -3,12 +3,12 @@ InstanceOf: JP_MedicationRequest
 Title: "JP MedicationRequest 内服処方1"
 Description: "内服処方1"
 Usage: #example
-* identifier[0].system = "urn:oid:1.2.392.100495.20.3.81"
-* identifier[=].value = "1"
-* identifier[+].system = "urn:oid:1.2.392.100495.20.3.82"
-* identifier[=].value = "1"
-* identifier[+].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
-* identifier[=].value = "1234567890.1.1"
+* identifier[RpNumber].system = "urn:oid:1.2.392.100495.20.3.81"
+* identifier[RpNumber].value = "1"
+* identifier[OrderInRp].system = "urn:oid:1.2.392.100495.20.3.82"
+* identifier[OrderInRp].value = "1"
+* identifier[RequestIdentifier].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
+* identifier[RequestIdentifier].value = "1234567890.1.1"
 * intent = #order
 * status = #active
 * medicationCodeableConcept = urn:oid:1.2.392.200119.4.403.1#103835401 "ムコダイン錠２５０ｍｇ"
@@ -34,12 +34,12 @@ InstanceOf: JP_MedicationRequest
 Title: "JP MedicationRequest 内服処方2"
 Description: "内服処方2"
 Usage: #example
-* identifier[0].system = "urn:oid:1.2.392.100495.20.3.81"
-* identifier[=].value = "2"
-* identifier[+].system = "urn:oid:1.2.392.100495.20.3.82"
-* identifier[=].value = "2"
-* identifier[+].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
-* identifier[=].value = "1234567890.1.2"
+* identifier[RpNumber].system = "urn:oid:1.2.392.100495.20.3.81"
+* identifier[RpNumber].value = "2"
+* identifier[OrderInRp].system = "urn:oid:1.2.392.100495.20.3.82"
+* identifier[OrderInRp].value = "2"
+* identifier[RequestIdentifier].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
+* identifier[RequestIdentifier].value = "1234567890.1.2"
 * intent = #order
 * status = #active
 * medicationCodeableConcept = urn:oid:1.2.392.200119.4.403.1#110626901 "パンスポリンＴ錠１００ １００ｍｇ"

--- a/input/fsh/examples/JP_MedicationRequest_Injection_Example.fsh
+++ b/input/fsh/examples/JP_MedicationRequest_Injection_Example.fsh
@@ -6,12 +6,12 @@ Usage: #example
 * contained[0] = jp-medicationrequest-injection-medication-example-1
 * contained[+] = jp-medicationrequest-injection-bodystructure-example-1
 * contained[+] = jp-medicationrequest-injection-device-example-1
-* identifier[0].system = "urn:oid:1.2.392.100495.20.3.81"
-* identifier[=].value = "1"
-* identifier[+].system = "urn:oid:1.2.392.100495.20.3.82"
-* identifier[=].value = "2"
-* identifier[+].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
-* identifier[=].value = "1234567890.1.1"
+* identifier[RpNumber].system = "urn:oid:1.2.392.100495.20.3.81"
+* identifier[RpNumber].value = "1"
+* identifier[OrderInRp].system = "urn:oid:1.2.392.100495.20.3.82"
+* identifier[OrderInRp].value = "2"
+* identifier[RequestIdentifier].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
+* identifier[RequestIdentifier].value = "1234567890.1.1"
 * status = #active
 * intent = #order
 * category[0] = http://terminology.hl7.org/CodeSystem/v2-0482#I "Inpatient Order"
@@ -44,12 +44,12 @@ Description: "点滴注射"
 Usage: #example
 * contained[0] = jp-medicationrequest-injection-medication-example-2
 * contained[+] = jp-medicationrequest-injection-bodystructure-example-2
-* identifier[0].system = "urn:oid:1.2.392.100495.20.3.81"
-* identifier[=].value = "2"
-* identifier[+].system = "urn:oid:1.2.392.100495.20.3.82"
-* identifier[=].value = "2"
-* identifier[+].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
-* identifier[=].value = "1234567890.2.1"
+* identifier[RpNumber].system = "urn:oid:1.2.392.100495.20.3.81"
+* identifier[RpNumber].value = "2"
+* identifier[OrderInRp].system = "urn:oid:1.2.392.100495.20.3.82"
+* identifier[OrderInRp].value = "2"
+* identifier[RequestIdentifier].system = "http://jpfhir.jp/fhir/Common/IdSystem/resourceInstance-identifier"
+* identifier[RequestIdentifier].value = "1234567890.2.1"
 * status = #active
 * intent = #order
 * category[0] = http://terminology.hl7.org/CodeSystem/v2-0482#I "Inpatient Order"


### PR DESCRIPTION
## 修正内容
- ローカルのsushiを `v2.6.0` に更新したところ、MedicationRequestのExamplesビルドで警告が発生するようになった。
  ```
  Sushi: warn  Sliced element MedicationRequest.identifier is being accessed via numeric index. Use slice names in rule paths when possible. (01:09.0516)
  Sushi: File: /Users/yoshinori.kodama/service/jp-core-v1x/input/fsh/examples/JP_MedicationRequest_Example.fsh (01:09.0523)
  Sushi: Line: 6
  ```
- 警告メッセージを解釈すると、identifierをindex指定で記述しているのをやめて、スライス名を使用するように推奨されているため、そのように修正した。
- 例: `identifier[0]` => `identifier[RpNumber]`

## 担当SWG
<!-- (SWG[1-6] もしくは アカウント名) -->
- SWG5

## Merge依頼先
<!-- (SGW[1-6] もしくは アカウント名) -->
<!-- 個人を指定するにはあわせてReviewersに設定すること-->
- 小林先生 @skoba 

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->
- warning対策のため、実装ガイドの出力結果に変更はございません。

## 補足

