### PR TITLE
JP_Observation_PhysicalExamプロファイルのbodySiteのExtension定義を削除

### DIFF
--- a/input/fsh/aliases-jpcore.fsh
+++ b/input/fsh/aliases-jpcore.fsh
@@ -64,7 +64,6 @@ Alias: $JP_MedicationRequest_DosageInstruction_Device = http://jpfhir.jp/fhir/co
 Alias: $JP_MedicationRequest_DosageInstruction_Line = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Line
 Alias: $JP_MedicationRequest_DosageInstruction_PeriodOfUse = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse
 Alias: $JP_MedicationRequest_DosageInstruction_UsageDuration = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration
-Alias: $JP_Observation_BodySite_BodySitePosition = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Observation_BodySite_BodySitePosition
 Alias: $JP_Organization_InsuranceOrganizationCategory = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationCategory
 Alias: $JP_Organization_InsuranceOrganizationNo = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationNo
 Alias: $JP_Organization_PrefectureNo = http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_PrefectureNo

--- a/input/fsh/aliases-jpcore.fsh
+++ b/input/fsh/aliases-jpcore.fsh
@@ -84,8 +84,8 @@ Alias: $JP_Patient_KanaSort_SP = http://jpfhir.jp/fhir/core/SearchParameter/JP_P
 
 // CodeSystem
 Alias: $JP_JfagyFoodAllergenCodes_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_JfagyFoodAllergenCodes_CS
-Alias: $JP_JfagyNonFoodNonMedicationAllergenCodes_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_JfagyNonFoodNonMedicationAllergenCodes_CS
 Alias: $JP_JfagyMedicationAllergenCodes_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_JfagyMedicationAllergenCodes_CS
+Alias: $JP_JfagyNonFoodNonMedicationAllergenCodes_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_JfagyNonFoodNonMedicationAllergenCodes_CS
 Alias: $JP_PhysicalExamCodes_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_PhysicalExamCodes_CS
 Alias: $JP_ProcedureBodySite_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_ProcedureBodySite_CS
 Alias: $JP_ProcedureCodesDental_CS = http://jpfhir.jp/fhir/Common/CodeSystem/JP_ProcedureCodesDental_CS

--- a/input/fsh/profiles/JP_Observation_BodyMeasurement.fsh
+++ b/input/fsh/profiles/JP_Observation_BodyMeasurement.fsh
@@ -27,20 +27,3 @@ Description: "このプロファイルはObservationリソースに対して、�
 * hasMember ^comment = "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](questionnaireresponse.html)  into a final score and represent the score as an Observation.\r\n\r\n【JP仕様】<br/>\r\n関連する参照リソースにJP_Observation_BodyMeasurementを追加"
 * derivedFrom only Reference(DocumentReference or ImagingStudy or Media or QuestionnaireResponse or JP_Observation_Common or MolecularSequence or JP_Observation_BodyMeasurement)
 * derivedFrom ^comment = "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](observation.html#obsgrouping) below.\r\n\r\n【JP仕様】<br/>\r\n導出元の参照リソースにJP_Observation_BodyMeasurementを追加"
-
-// ==============================
-//   Extension 定義
-// ==============================
-Extension: JP_Observation_BodySite_BodySitePosition
-Id: jp-observation-bodysite-bodysiteposition
-Title: "JP Core Observation BodySite BodySitePosition Extension"
-Description: "部位（bodySite）の左右の区別を表現する際に使用する"
-* ^url = "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Observation_BodySite_BodySitePosition"
-* ^context.type = #element
-* ^context.expression = "Observation.bodySite"
-* . ..1
-* . ^short = "部位（bodySite）の左右の区別を表現する際に使用する"
-* . ^definition = "部位（bodySite）の左右の区別を表現する際に使用する"
-* . ^comment = "部位（bodySite）の左右の区別を表現する際に使用する"
-* url = "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Observation_BodySite_BodySitePosition" (exactly)
-* value[x] only string or CodeableConcept

--- a/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
+++ b/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
@@ -6,7 +6,6 @@ Parent: JP_Observation_Common
 Id: jp-observation-physicalexam
 Title: "JP Core Observation PhysicalExam Profile"
 Description: "このプロファイルはObservationリソースに対して、身体所見のデータを送受信するための制約と拡張を定めたものである。"
-* bodySite.extension contains JP_Observation_BodySite_BodySitePosition named bodySitePosition ..*
 * ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Observation_PhysicalExam"
 * ^status = #draft
 * . ^short = "身体所見に関する測定や簡単な観察事実（assertion）"
@@ -30,12 +29,7 @@ Description: "このプロファイルはObservationリソースに対して、�
 * value[x] ^comment = "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](observation.html#notes) below.\r\n\r\n【JP仕様】<br/>\r\nコードに限定する"
 * value[x] ^binding.description = "Codes specifying either Yes or No used in fields containing binary answers generally user-specified."
 * bodySite from $observation-bodySite (preferred)
-* bodySite ^comment = "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](extension-bodysite.html).\r\n\r\n【JP仕様】<br/>\r\n外保連の手術基幹コード（STEM7）の操作対象部位を基にバリューセットを定義する<br/>\r\n左右の区別は拡張で表現する<br/>\r\n具体的なコードについてはSWG6と連携して決定する必要がある（TBD）"
-* bodySite.extension ^slicing.discriminator.type = #value
-* bodySite.extension ^slicing.discriminator.path = "url"
-* bodySite.extension ^slicing.rules = #open
-* bodySite.extension[bodySitePosition] only JP_Observation_BodySite_BodySitePosition
-* bodySite.extension[bodySitePosition] ^comment = "左右の区別を表現する際に使用する"
+* bodySite ^comment = "ICD-11"
 * method from $observation-method (preferred)
 * method ^comment = "Only used if not implicit in code for Observation.code.\r\n\r\n【JP仕様】<br/>\r\n症状・所見マスターの「診察方法」を基にバリューセットを定義する<br/>\r\n具体的なコードについてはSWG6と連携して決定する必要がある（TBD）"
 * hasMember only Reference(JP_Observation_Common or QuestionnaireResponse or MolecularSequence or JP_Observation_PhysicalExam)

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -96,7 +96,9 @@
 [JP_Patient_KanaSort_SP]: SearchParameter-jp-patient-kanasort-sp.html
 
 <!-- CodeSystem -->
-[JP_JFAGY_CS]: CodeSystem-jp-jfagy-cs.html
+[JP_JfagyFoodAllergenCodes_CS]: CodeSystem-jp-jfagy-food-allergen-codes-cs.html
+[JP_JfagyMedicationAllergenCodes_CS]: CodeSystem-jp-jfagy-medication-allergen-codes-cs.html
+[JP_JfagyNonFoodNonMedicationAllergenCodes_CS]: CodeSystem-jp-jfagy-non-food-non-medication-allergen-codes-cs.html
 [JP_PhysicalExamCodes_CS]: CodeSystem-jp-physicalexamcodes-cs.html
 [JP_ProcedureBodySite_CS]: CodeSystem-jp-procedure-body-site-cs.html
 [JP_ProcedureCodesDental_CS]: CodeSystem-jp-procedure-codes-dental-cs.html
@@ -113,9 +115,7 @@
 [JP_ProcedureReasonCodes_CS]: CodeSystem-jp-procedure-reason-codes-cs.html
 
 <!-- ValueSet -->
-[JP_AllergyIntoleranceCodesFood_VS]: ValueSet-jp-allergyintolerance-codes-food-vs.html
-[JP_AllergyIntoleranceCodesMedicine_VS]: ValueSet-jp-allergyintolerance-codes-medicine-vs.html
-[JP_AllergyIntoleranceCodesNonFoodNonMedicine_VS]: ValueSet-jp-allergyintolerance-codes-non-food-non-medicine-vs.html
+[JP_AllergyIntoleranceCodes_VS]: ValueSet-jp-allergyintolerance-codes-vs.html
 [JP_PhysicalExamCodes_VS]: ValueSet-jp-physicalexamcodes-vs.html
 [JP_ProcedureBodySite_VS]: ValueSet-jp-procedure-body-site-vs.html
 [JP_ProcedureCodesMedical_VS]: ValueSet-jp-procedure-code-medical-vs.html
@@ -137,7 +137,6 @@
 [jp-diagnosticreport-radiology-example-1]: DiagnosticReport-jp-diagnosticreport-radiology-example-1.html
 [jp-encounter-example1]: Encounter-jp-encounter-example1.html
 [jp-immunization-example-1]: Immunization-jp-immunization-example-1.html
-[jp-location-example-examinationroom]: Location-jp-location-example-examinationroom.html
 [jp-location-example-ope]: Location-jp-location-example-ope.html
 [jp-location-example-ward]: Location-jp-location-example-ward.html
 [jp-medication-example-1]: Medication-jp-medication-example-1.html
@@ -157,12 +156,10 @@
 [jp-observation-socialhistory-example-1]: Observation-jp-observation-socialhistory-example-1.html
 [jp-observation-vitalsigns-example-1]: Observation-jp-observation-vitalsigns-example-1.html
 [jp-organization-example-clinic]: Organization-jp-organization-example-clinic.html
-[jp-organization-example-hospital]: Organization-jp-organization-example-hospital.html
 [jp-organization-example-payer]: Organization-jp-organization-example-payer.html
 [jp-patient-example-1]: Patient-jp-patient-example-1.html
 [jp-practionner-example-female-1]: Practitioner-jp-practionner-example-female-1.html
 [jp-practionner-example-female-2]: Practitioner-jp-practionner-example-female-2.html
 [jp-practionner-example-male-1]: Practitioner-jp-practionner-example-male-1.html
 [jp-practionner-example-male-2]: Practitioner-jp-practionner-example-male-2.html
-[jp-procedurerole-example-1]: PractitionerRole-jp-procedurerole-example-1.html
 [jp-procedure-example-1]: Procedure-jp-procedure-example-1.html

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -77,7 +77,6 @@
 [JP_MedicationRequest_DosageInstruction_Line]: StructureDefinition-jp-medicationrequest-dosageinstruction-line.html
 [JP_MedicationRequest_DosageInstruction_PeriodOfUse]: StructureDefinition-jp-medicationrequest-dosageinstruction-periodofuse.html
 [JP_MedicationRequest_DosageInstruction_UsageDuration]: StructureDefinition-jp-medicationrequest-dosageinstruction-usageduration.html
-[JP_Observation_BodySite_BodySitePosition]: StructureDefinition-jp-observation-bodysite-bodysiteposition.html
 [JP_Organization_InsuranceOrganizationCategory]: StructureDefinition-jp-organization-insuranceorganizationcategory.html
 [JP_Organization_InsuranceOrganizationNo]: StructureDefinition-jp-organization-insuranceorganizationno.html
 [JP_Organization_PrefectureNo]: StructureDefinition-jp-organization-prefectureno.html

--- a/input/intro-notes/StructureDefinition-jp-observation-physicalexam-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-observation-physicalexam-notes.md
@@ -16,10 +16,7 @@
 このプロファイルでは MustSupport要素定義は行っていない。
 
 ### Extensions定義
-本プロファイルで使用される拡張は次の通りである。
-
-- [`JPCoreBodySitePositionExtension`][JP_Observation_BodySite_BodySitePosition]
-  - 部位（bodySite）の左右の区別を表現する際に使用する。
+このプロファイルでは拡張定義は行っていない。
 
 ## 利用方法
 
@@ -88,12 +85,6 @@ Observationリソースのインタラクション一覧の定義はユースケ
     ]
   },
   "bodySite": {
-    "extension": [
-      {
-        "url": "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Observation_BodySite_BodySitePosition",
-        "valueString": "右"
-      }
-    ],
     "coding": [
       {
         "system": "http://jpfhir.jp/fhir/Common/CodeSystem/observation-bodySite",

--- a/input/pagecontent/group-diagnostic.md
+++ b/input/pagecontent/group-diagnostic.md
@@ -14,6 +14,6 @@
     * [JP Core DiagnosticReport Radiology （放射線検査レポート）プロファイル][JP_DiagnosticReport_Radiology]
 
 ### Extensions
-* [JP_Observation_BodySite_BodySitePosition]
+なし
 
 {% include markdown-link-references.md %}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -165,7 +165,6 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_Line
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_PeriodOfUse
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationRequest_DosageInstruction_UsageDuration
-    - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Observation_BodySite_BodySitePosition
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationCategory
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_InsuranceOrganizationNo
     - http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Organization_PrefectureNo


### PR DESCRIPTION
## 修正内容
[#165](https://github.com/jami-fhir-jp-wg/jp-core-v1x/issues/165)による修正

## 担当SWG
SWG2

## Merge依頼先
SWG1

## 関連ISSUE
[#165](https://github.com/jami-fhir-jp-wg/jp-core-v1x/issues/165)

## 補足
SWG6（今井先生）との議論により、拡張は使用せずICD-11で表現することとした。
