### PR TITLE
swg4 リンクの表現方法修正＆参照元情報の削除

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-allergyintolerance-intro.md
+++ b/input/intro-notes/StructureDefinition-jp-allergyintolerance-intro.md
@@ -11,6 +11,5 @@
 本プロファイルは、以下のようなユースケースを想定する。
 
 - AllergyIntoleranceリソースの記録・更新・検索。
-- 他リソースからの参照（例：AdverseEvent, FamilyMemberHistory）
 
 ## プロファイル定義

--- a/input/intro-notes/StructureDefinition-jp-allergyintolerance-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-allergyintolerance-notes.md
@@ -176,7 +176,7 @@
 
 ## 注意事項
 
-- Negated Allergies and Intolerances. [https://hl7.org/fhir/R4/allergyintolerance.html#9.1.3.3]
+- Negated Allergies and Intolerances. [https://hl7.org/fhir/R4/allergyintolerance.html#9.1.3.3](https://hl7.org/fhir/R4/allergyintolerance.html#9.1.3.3)
 
 ## その他、参考文献・リンク等
 

--- a/input/intro-notes/StructureDefinition-jp-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-jp-condition-intro.md
@@ -11,6 +11,5 @@
 本プロファイルは、以下のようなユースケースを想定する。
 
 - Conditionリソースの記録・更新・検索。
-- 他のリソースからの参照（例：FamilyMemberHistory, Observation, Procedure）
 
 ## プロファイル定義

--- a/input/intro-notes/StructureDefinition-jp-condition-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-condition-notes.md
@@ -131,4 +131,4 @@
 
 ## その他、参考文献・リンク等
 
-- HL70421 Severity of Illness Code ... JAHIS データ交換規約（共通編）Ver1.3 p.119 [https://www.jahis.jp/files/user/04_JAHIS%20standard/22-003_JAHIS%20%E3%83%87%E3%83%BC%E3%82%BF%E4%BA%A4%E6%8F%9B%E8%A6%8F%E7%B4%84%EF%BC%88%E5%85%B1%E9%80%9A%E7%B7%A8%EF%BC%89Ver.1.3.pdf]
+- HL70421 Severity of Illness Code ... JAHIS データ交換規約（共通編）Ver1.3 p.119 [https://www.jahis.jp/files/user/04_JAHIS%20standard/22-003_JAHIS%20データ交換規約（共通編）Ver.1.3.pdf](https://www.jahis.jp/files/user/04_JAHIS%20standard/22-003_JAHIS%20データ交換規約（共通編）Ver.1.3.pdf)

--- a/input/intro-notes/StructureDefinition-jp-procedure-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-procedure-notes.md
@@ -112,4 +112,4 @@
 
 ## その他、参考文献・リンク等
 
-- ICHI(International Classification of Health Interventions)[https://icd.who.int/dev11/l-ichi/en]
+- ICHI(International Classification of Health Interventions) [https://icd.who.int/dev11/l-ichi/en](https://icd.who.int/dev11/l-ichi/en)


### PR DESCRIPTION
## 修正内容
- リンクの表現方法修正
記述方法変更

- 参照元情報の削除
全体会議にて削除する方針となったため。

## 担当SWG
SWG4

## Merge依頼先
SWG4

## レビュー観点
内容の確認をお願いします。
