### PR TITLE
swg4 CodeSystemにValueSetが定義されており循環参照状態に

### DIFF
--- a/input/fsh/terminologies/JP_PhysicalExamCodes_CS.fsh
+++ b/input/fsh/terminologies/JP_PhysicalExamCodes_CS.fsh
@@ -5,7 +5,6 @@ Description: "身体所見の区分を表すコード"
 * ^url = $JP_PhysicalExamCodes_CS
 * ^status = #draft
 * ^caseSensitive = true
-* ^valueSet = $JP_PhysicalExamCodes_VS
 * ^content = #complete
 * #physical-findings "Physical Findings"
 * #detailed-physical-findings "Detailed Physical Findings"


### PR DESCRIPTION
## 修正内容
CodeSystemの中にValueSetが定義されているが、そのValueSetもCodeSystemを定義している。
基本CodeSystem側でValueSetを意識する必要はないため、定義をしないほうがいいのでは。

## 担当SWG
SWG4

## Merge依頼先
SWG4
