### PR TITLE
swg3 ss-mix標準ストレージのPDF 1.2Fが見えなくなった

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-encounter-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-encounter-notes.md
@@ -228,8 +228,8 @@ Encounterリソースは、予定情報や予約の保存には使用されな�
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)

--- a/input/intro-notes/StructureDefinition-jp-location-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-location-notes.md
@@ -231,8 +231,8 @@ Locationに対するOperationは定義されていない。
 ・特定健診情報ファイル仕様
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)

--- a/input/intro-notes/StructureDefinition-jp-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-organization-notes.md
@@ -158,8 +158,8 @@ Operationは特にない。
 ・特定健診情報ファイル仕様
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)

--- a/input/intro-notes/StructureDefinition-jp-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-patient-notes.md
@@ -333,8 +333,8 @@ HTTP/1.1 200 OK
 ・特定健診情報ファイル仕様
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)

--- a/input/intro-notes/StructureDefinition-jp-practitioner-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-practitioner-notes.md
@@ -178,8 +178,8 @@ Operationはない。
 ・特定健診情報ファイル仕様
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)

--- a/input/intro-notes/StructureDefinition-jp-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-practitionerrole-notes.md
@@ -93,8 +93,8 @@ PractitionerRoleには、ここで定義されているlocationに住所が含�
 ・特定健診情報ファイル仕様
 [https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html](https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000165280.html)
 
-・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2f
-[http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf](http://www.jami.jp/jamistd/docs/SS-MIX2/f/SS-MIX2_StndrdStrgSpecVer.1.2f.pdf)
+・SS-MIX2 標準化ストレージ 仕様書 Ver.1.2h
+[https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf](https://www.jami.jp/jamistd/docs/SS-MIX2/h/SS-MIX2_StndrdStrgSpecVer.1.2h.pdf)
 
 ・ICSR E2B(R3)
 [https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html](https://www.pmda.go.jp/int-activities/int-harmony/ich/0093.html)


### PR DESCRIPTION
## 修正内容
ss-mix標準ストレージのPDF 1.2fの仕様書のリンクが消えてしまった。
後継と思われる仕様書があったので、付け替えをしました。

## Merge依頼先
swg3

## レビュー観点

- 付け替えた仕様書が正しいか、仕様的に矛盾を生じないか確認をお願いします。
