### PR TITLE
SWG5 fixed wrong description in JP_Medication

### DIFF
--- a/input/fsh/profiles/JP_Medication.fsh
+++ b/input/fsh/profiles/JP_Medication.fsh
@@ -75,10 +75,10 @@ Description: "このプロファイルはMedicationリソースに対して、�
 Extension: JP_Medication_Ingredient_DrugNo
 Id: jp-medication-ingredient-drugno
 Title: "JP Core Medication Ingredient DrugNo Extension"
-Description: "投与量が製剤単位か成分単位かを格納する拡張"
+Description: "同一剤グループ内での順番を格納する拡張"
 * ^url = "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Medication_Ingredient_DrugNo"
 * ^date = "2022-03-16"
-* ^purpose = "投与量が製剤単位か成分単位かを格納する拡張"
+* ^purpose = "同一剤グループ内での順番を格納する拡張"
 * ^context.type = #element
 * ^context.expression = "Medication.ingredient"
 * . ^short = "RP内の薬剤の連番"


### PR DESCRIPTION
## 修正内容

JP_MedicationでのDrugNo extensionに対する記載がStrengthTypeのものとなっていた。

## Merge依頼先
SWG5

## レビュー観点
表記の間違い

## 関連ISSUE
なし

## 補足
