### PR TITLE
swg5 MedicationRequestBaase CodingのCardinality制約を削除

### DIFF
--- a/input/fsh/profiles/JP_MedicationRequestBase.fsh
+++ b/input/fsh/profiles/JP_MedicationRequestBase.fsh
@@ -343,7 +343,6 @@ Description: "このプロファイルはユーザは直接適用するもので
 * dosageInstruction.route ^requirements = "治療薬剤が患者の体内に投与される生理学的な経路を特定するためのコード。"
 * dosageInstruction.route.id ^short = "エレメント間参照のためのユニークID"
 * dosageInstruction.route.id ^definition = "エレメント間参照のためのユニークID。空白を含まない全ての文字を使ってもよい(MAY)。"
-* dosageInstruction.route.coding 1..1
 * dosageInstruction.route.coding ^short = "JAMI 用法コード表投与経路区分２桁コード"
 * dosageInstruction.route.coding ^definition = "JAMI 用法コード表投与経路区分２桁コードを識別するURI。JP Coreでは必須。"
 * dosageInstruction.route.coding ^comment = "コードは臨時で列記したものや、コードのリストからSNOMED CTのように公式に定義されたものまである（HL7 v3 core principle を参照)。FHIR自体ではコーディング規約を定めてはいないし、意味を暗示するために利用されない(SHALL NOT)。一般的に UserSelected = trueの場合には一つのコードシステムが使われる。"
@@ -463,7 +462,6 @@ Description: "このプロファイルはユーザは直接適用するもので
 * dosageInstruction.doseAndRate.type ^requirements = "このtypeに値が指定されていなければ、\"ordered\"であることが想定される。"
 * dosageInstruction.doseAndRate.type.id ^short = "エレメント間参照のためのユニークID"
 * dosageInstruction.doseAndRate.type.id ^definition = "エレメント間参照のためのユニークID。空白を含まない全ての文字を使ってもよい(MAY)。"
-* dosageInstruction.doseAndRate.type.coding 1..1
 * dosageInstruction.doseAndRate.type.coding ^short = "力価区分コード"
 * dosageInstruction.doseAndRate.type.coding ^definition = "力価区分コード"
 * dosageInstruction.doseAndRate.type.coding ^comment = "コードは臨時で列記したものや、コードのリストからSNOMED CTのように公式に定義されたものまである（HL7 v3 core principle を参照)。FHIR自体ではコーディング規約を定めてはいないし、意味を暗示するために利用されない(SHALL NOT)。一般的に UserSelected = trueの場合には一つのコードシステムが使われる。"
@@ -813,7 +811,6 @@ Description: "このプロファイルはユーザは直接適用するもので
 * substitution.allowed[x] ^short = "後発医薬品への変更可否情報。"
 * substitution.allowed[x] ^definition = "後発医薬品への変更可否情報。"
 * substitution.allowed[x] ^comment = "代替品が許可されるかどうかは無視できないので、このエレメントはmodifierとしてラベルされる。"
-* substitution.allowed[x].coding 1..1
 * substitution.allowed[x].coding ^short = "後発品変更不可コード"
 * substitution.allowed[x].coding ^definition = "後発品変更不可コード。"
 * substitution.allowed[x].coding.system 1..


### PR DESCRIPTION
## 修正内容
MedicationRequestBaase CodingのCardinality制約を削除

## Merge依頼先
SWG5 

## レビュー観点

テキストでの記載もあり得るため、Cardinalityの制約を削除した

## 関連ISSUE
fixed #312 

## 補足
