### PR TITLE
swg4 警告対応code systemの指定

### DIFF
--- a/input/fsh/examples/JP_FamilyMemberHistory_Example.fsh
+++ b/input/fsh/examples/JP_FamilyMemberHistory_Example.fsh
@@ -11,7 +11,10 @@ Usage: #example
   * coding[0]
     * system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
     * code = #MTH
-* sex = #female
+* sex
+  * coding[0]
+    * system = http://hl7.org/fhir/administrative-gender
+    * code = #female
 * reasonCode[0]
   * text = "難聴"
 * condition[0]

--- a/input/fsh/examples/JP_FamilyMemberHistory_Example.fsh
+++ b/input/fsh/examples/JP_FamilyMemberHistory_Example.fsh
@@ -13,7 +13,7 @@ Usage: #example
     * code = #MTH
 * sex
   * coding[0]
-    * system = http://hl7.org/fhir/administrative-gender
+    * system = "http://hl7.org/fhir/administrative-gender"
     * code = #female
 * reasonCode[0]
   * text = "難聴"


### PR DESCRIPTION
## 修正内容
sexがFamilyMemberHistoryの場合、CodeableConcept型となっているため、Systemが必要になる。
qa.htmlに警告としてあがっていたため、対処。

## Merge依頼先
SWG4
