### PR TITLE
swg2 ローカルコードを許容する

### DIFF
--- a/input/fsh/examples/JP_Observation_PhysicalExam_Example.fsh
+++ b/input/fsh/examples/JP_Observation_PhysicalExam_Example.fsh
@@ -5,7 +5,7 @@ Description: "身体所見（腹痛）"
 Usage: #example
 * status = #final
 * category[exam] = $observation-category#exam "Exam"
-* code = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings"
+* code.coding[physicalFindings] = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings"
 * subject = Reference(Patient/jp-patient-example-1)
 * encounter = Reference(Encounter/jp-encounter-example-1)
 * effectiveDateTime = "2021-07-09T17:00:00+09:00"
@@ -14,5 +14,5 @@ Usage: #example
 * bodySite.text = "下腹部"
 //TODO: コーディング不明のためTextで回避
 * method.text = "触診"
-* component.code = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings"
+* component.code.coding[physicalFindings] = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings"
 * component.valueString = "圧痛あり"

--- a/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
+++ b/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
@@ -18,9 +18,13 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category contains exam 1..1
 * category[exam] = $observation-category#exam
 * category ^comment = "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.\r\n\r\n【JP Core仕様】基底仕様のカテゴリ「exam」固定とする"
-* code = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings" (exactly)
-* code from JP_PhysicalExamCode_VS (required)
-* code ^comment = "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】所見の有無を表すコード（固定値）"
+* code.coding ^slicing.discriminator.type = #pattern
+* code.coding ^slicing.discriminator.path = "$this"
+* code.coding ^slicing.rules = #open
+* code.coding contains physicalFindings 1..1
+* code.coding[physicalFindings] = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings" (exactly)
+* code.coding[physicalFindings] from JP_PhysicalExamCode_VS (required)
+* code.coding[physicalFindings] ^comment = "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】所見の有無を表すコード（固定値）"
 * subject 1..
 * subject only Reference(JP_Patient)
 * subject ^comment = "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.\r\n\r\n【JP Core仕様】患者"
@@ -28,7 +32,7 @@ Description: "このプロファイルはObservationリソースに対して、�
 * effective[x] only dateTime or Period
 * effective[x] ^comment = "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.\r\n\r\n【JP Core仕様】effectiveDateTime：医療者が確認した日時\r\n\r\neffectivePeriod：医療者が確認した期間"
 * value[x] only CodeableConcept
-* value[x] from $v2-0136 (required)
+* value[x] from $v2-0136 (preferred)
 * value[x] ^comment = "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](observation.html#notes) below.\r\n\r\n【JP Core仕様】コードに限定する"
 * value[x] ^binding.description = "Codes specifying either Yes or No used in fields containing binary answers generally user-specified."
 * bodySite from JP_ObservationPhysicalExamBodySite_VS (preferred)
@@ -40,7 +44,11 @@ Description: "このプロファイルはObservationリソースに対して、�
 * derivedFrom only Reference(DocumentReference or ImagingStudy or Media or QuestionnaireResponse or JP_Observation_Common or MolecularSequence or JP_Observation_PhysicalExam)
 * derivedFrom ^comment = "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](observation.html#obsgrouping) below.\r\n\r\n【JP Core仕様】導出元の参照リソースにJP_Observation_PhysicalExamを追加"
 * component ^comment = "For a discussion on the ways Observations can be assembled in groups together see [Notes](observation.html#notes) below.\r\n\r\n【JP Core仕様】具体的な所見を記載する"
-* component.code = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings" (exactly)
-* component.code from JP_PhysicalExamCode_VS (required)
-* component.code ^comment = "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】具体的な所見を表すコード（固定値）"
+* component.code.coding ^slicing.discriminator.type = #pattern
+* component.code.coding ^slicing.discriminator.path = "$this"
+* component.code.coding ^slicing.rules = #open
+* component.code.coding contains physicalFindings 1..1
+* component.code.coding = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings" (exactly)
+* component.code.coding from JP_PhysicalExamCode_VS (required)
+* component.code.coding ^comment = "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】具体的な所見を表すコード（固定値）"
 * component.value[x] only CodeableConcept or string


### PR DESCRIPTION
## 修正内容
ローカルコードを許容する

- fixed valueをcodingに対してSlicing
- バインディング強度をrequired→prefferedに変更

## Merge依頼先
swg2

## レビュー観点

- 警告の数が増えていないか
- ローカルコードが許容されるようになったか？

## 関連ISSUE
fixed #330

## 補足
