### PR TITLE
投与装置の「使用者定義表0164」が「使用者定義表0162」となっている間違いの修正

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-medicationdispense-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationdispense-injection-notes.md
@@ -52,7 +52,7 @@ HL7 ver 2系では用語集を識別するコーディングシステム名(以�
 |投与部位|JAMI処方・注射オーダ標準用法規格(部位コード)|urn:oid:1.2.392.200250.2.2.20.32|
 |投与部位|HL7 V2(HL7表0550)|http://terminology.hl7.org/CodeSystem/v2-0550|
 |投与部位(修飾子)|HL7 V2(HL7表0495)|http://terminology.hl7.org/CodeSystem/v2-0495|
-|投与装置|HL7 V2(使用者定義表0162)|http://terminology.hl7.org/CodeSystem/v2-0162|
+|投与装置|HL7 V2(使用者定義表0164)|http://terminology.hl7.org/CodeSystem/v2-0164|
 |投与方法|JAMI処方・注射オーダ標準用法規格(基本用法区分)|urn:oid:1.2.392.200250.2.2.20.30|
 |投与手技|HL7 V2(使用者定義表0165)|http://terminology.hl7.org/CodeSystem/v2-0165|
 |投与手技|JAMI処方・注射オーダ標準用法規格(用法詳細区分)|urn:oid:1.2.392.200250.2.2.20.40|

--- a/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
@@ -65,7 +65,7 @@ HL7 ver 2系では用語集を識別するコーディングシステム名(以�
 |投与部位|JAMI処方・注射オーダ標準用法規格(部位コード)|urn:oid:1.2.392.200250.2.2.20.32|
 |投与部位|HL7 V2(HL7表0550)|http://terminology.hl7.org/CodeSystem/v2-0550|
 |投与部位(修飾子)|HL7 V2(HL7表0495)|http://terminology.hl7.org/CodeSystem/v2-0495|
-|投与装置|HL7 V2(使用者定義表0162)|http://terminology.hl7.org/CodeSystem/v2-0162|
+|投与装置|HL7 V2(使用者定義表0164)|http://terminology.hl7.org/CodeSystem/v2-0164|
 |投与方法|JAMI処方・注射オーダ標準用法規格(基本用法区分)|urn:oid:1.2.392.200250.2.2.20.30|
 |投与手技|HL7 V2(使用者定義表0165)|http://terminology.hl7.org/CodeSystem/v2-0165|
 |投与手技|JAMI処方・注射オーダ標準用法規格(用法詳細区分)|urn:oid:1.2.392.200250.2.2.20.40|


### PR DESCRIPTION
## 修正内容
投与装置の「使用者定義表0164」が「使用者定義表0162」となっている間違いの修正

## Merge依頼先
SWG5 @skoba 

## レビュー観点
・定義表の重複が残っていないか
・投与装置の表番号が間違っていないか

## 関連ISSUE
fixed #400 

## 補足
