### PR TITLE
swg2 FixedValue警告回避。0..1のスライスを作成し推奨値を格納した

### DIFF
--- a/input/fsh/profiles/JP_DiagnosticReport_LabResult.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_LabResult.fsh
@@ -20,12 +20,18 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 * category ^slicing.discriminator.type = #pattern
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
-* category ^slicing.ordered = false
 * category contains laboratory 1..1
-* category[laboratory] = $diagnostic-service-sectionid-cs#LAB (exactly)
+* category[laboratory] = $diagnostic-service-sectionid-cs#LAB
 * category[laboratory] ^comment = "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.\r\nさまざまなカテゴリ化スキームを使用して、複数のカテゴリを使用できる。粒度のレベルは、それぞれの値セットのカテゴリの概念によって定義される。 DiagnosticReport.codeのメタデータや用語の階層を使用して、よりきめ細かいフィルタリングを実行できる。\r\n\r\n【JP Core仕様】Diagnostic Service Section Codesの\"LAB\"を使用"
-* code = http://loinc.org#11502-2 "Laboratory report" (exactly)
 * code ^comment = "Not all terminology uses fit this general pattern. In some cases, models should not use CodeableConcept and use Coding directly and provide their own structure for managing text, codings, translations and the relationship between elements and pre- and post-coordination.\r\nすべてのターミのロジーの使用がこの一般的なパターンに適合するわけではない。場合によっては、モデルはCodeableConceptを使用せず、コーディングを直接使用して、テキスト、コーディング、翻訳、および要素と事前・事後の用語作成（pre- and post-coordination）との関係を管理するための独自の構造を提供する必要がある。\r\n\r\n【JP Core仕様】LOINCの臨床検査の分類コードを割り当てる。\r\n\r\n検査レポートの利用用途に合わせて、JLAC10のコードを振っても良い。"
+* code.coding ^slicing.discriminator.type = #pattern
+* code.coding ^slicing.discriminator.path = "$this"
+* code.coding ^slicing.rules = #open
+* code.coding contains laboratoryCode 0..1
+* code.coding[laboratoryCode] = http://loinc.org#11502-2 "Laboratory report"
+* code.coding[laboratoryCode] ^short = "検体検査レポート項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。【詳細参照】"
+* code.coding[laboratoryCode] ^definition = "検体検査レポート項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。"
+* code.coding[laboratoryCode] ^comment = "推奨コードは必須ではない、派生先によるコード体系を作成し割り振ることを否定しない"
 * subject only Reference(JP_Patient)
 * subject ^short = "The subject of the report - usually, but not always, the patient　レポートの対象、常にではないが、通常は患者"
 * subject ^comment = "References SHALL be a reference to an actual FHIR resource, and SHALL be resolvable (allowing for access control, temporary unavailability, etc.). Resolution can be either by retrieval from the URL, or, where applicable by resource type, by treating an absolute reference as a canonical URL and looking it up in a local registry/repository.\r\n参照は、実際のFHIRリソースへの参照である必要があり、内容に辿り着ける（解決できる）必要がある（アクセス制御、一時的な使用不可などを考慮に入れる）。解決は、URLから取得するか、リソースタイプによって該当する場合は、絶対参照を正規URLとして扱い、ローカルレジストリ/リポジトリで検索することによって行うことができる。\r\n\r\n【JP Core仕様】Patientリソースを参照"

--- a/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
+++ b/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
@@ -18,9 +18,16 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category contains exam 1..1
 * category[exam] = $observation-category#exam
 * category ^comment = "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.\r\n\r\n【JP Core仕様】基底仕様のカテゴリ「exam」固定とする"
-* code = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings" (exactly)
-* code from JP_PhysicalExamCode_VS (preferred)
 * code ^comment = "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】所見の有無を表すコード（固定値）"
+* code from JP_PhysicalExamCode_VS (preferred)
+* code.coding ^slicing.discriminator.type = #pattern
+* code.coding ^slicing.discriminator.path = "$this"
+* code.coding ^slicing.rules = #open
+* code.coding contains physicalExamCode 0..1
+* code.coding[physicalExamCode] = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings"
+* code.coding[physicalExamCode] ^short = "身体所見項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。【詳細参照】"
+* code.coding[physicalExamCode] ^definition = "身体所見項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。"
+* code.coding[physicalExamCode] ^comment = "推奨項目コードは必須ではない、派生先によるコード体系を作成し割り振ることを否定しない"
 * subject 1..
 * subject only Reference(JP_Patient)
 * subject ^comment = "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.\r\n\r\n【JP Core仕様】患者"
@@ -39,6 +46,13 @@ Description: "このプロファイルはObservationリソースに対して、�
 * derivedFrom ^comment = "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](observation.html#obsgrouping) below.\r\n\r\n【JP Core仕様】導出元の参照リソースにJP_Observation_PhysicalExamを追加"
 * component ^comment = "For a discussion on the ways Observations can be assembled in groups together see [Notes](observation.html#notes) below.\r\n\r\n【JP Core仕様】具体的な所見を記載する"
 * component ^short = "所見有り（valueCodeableConceptがY）の場合に、具体的な所見をコード、または文字列で記載する"
-* component.code = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings" (exactly)
 * component.code from JP_PhysicalExamCode_VS (preferred)
 * component.code ^comment = "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.\r\n\r\n【JP Core仕様】具体的な所見を表すコード（固定値）"
+* component.code.coding ^slicing.discriminator.type = #pattern
+* component.code.coding ^slicing.discriminator.path = "$this"
+* component.code.coding ^slicing.rules = #open
+* component.code.coding contains physicalExamCode 0..1
+* component.code.coding[physicalExamCode] = $JP_PhysicalExamCode_CS#detailed-physical-findings "Detailed Physical Findings"
+* component.code.coding[physicalExamCode] ^short = "身体所見項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。【詳細参照】"
+* component.code.coding[physicalExamCode] ^definition = "身体所見項目コード。本ユースケースにおける項目コード推奨値をスライスにて示している。"
+* component.code.coding[physicalExamCode] ^comment = "推奨項目コードは必須ではない、派生先によるコード体系を作成し割り振ることを否定しない"


### PR DESCRIPTION
## 修正内容
FixedValue警告回避。0..1のスライスを作成し推奨値を格納した。
IG PublisherにてFixed Valueに対する警告が発生したため、Slicing(valueSetを利用しない）方法での回避を行った。

## Merge依頼先
SWG2

## レビュー観点

- コメントを作成したが、内容についての可否
- Fixed Valueの回避方法（1件のValueSetを作成するよりもスマートだと思ったのでこのように修正した）
