### PR TITLE
swg5-formの説明をMERIT9ベースの変更

### DIFF
--- a/input/fsh/profiles/JP_Medication.fsh
+++ b/input/fsh/profiles/JP_Medication.fsh
@@ -32,7 +32,8 @@ Description: "このプロファイルはMedicationリソースに対して、�
 * manufacturer only Reference(JP_Organization)
 * manufacturer ^short = "製品の製造者"
 * manufacturer ^definition = "Describes the details of the manufacturer of the medication product.  This is not intended to represent the distributor of a medication product.\r\n\r\n医薬品の製造元の詳細を説明する。これは、医薬品の販売業者を表すことを意図したものではない。"
-* form ^definition = "製品の剤型についての説明。散剤(powder)、錠剤(tablets)、カプセル(capsule)など。"
+* form ^short = "TAB | CAP | PWD | SYR | SUP | LQD | OIT | CRM | TPE | INJ +"
+* form ^definition = "TAB | CAP | PWD | SYR | SUP | LQD | OIT | CRM | TPE | INJ + 製品の剤型についての説明。散剤、ドライシロップ(PWD)、錠剤(TAB)、カプセル(CAP)など。"
 * form ^comment = "もし、Medication ResourceがMedicationRequest Resourceから参照された場合は、これはオーダされた剤型である。Medication ResourceがMedicationDispense Resourceから参照された場合は、払い出された剤型である。MedicationAdministration ResourceからMedication Resourceが参照されていれば、投与された剤型である。"
 * amount only JP_MedicationRatio_Amount
 * amount ^short = "パッケージ中の薬剤の量"


### PR DESCRIPTION
## 修正内容
formの説明をMERIT9ベースの変更
FHIR BASEの説明が残っていたため。

## Merge依頼先
SWG5

## レビュー観点

- 内容に不整合等がないか。
- 今回注射のみの利用なので、記述としてもう少し説明を加えなくて大丈夫か。

## 関連ISSUE
fixed #479

## 備考
[ビルド結果](https://jami-fhir-jp-wg.github.io/jp-core-v1xpages/jpcore-r4/feature/swg5-Medicaion_form%E3%81%AE%E8%AA%AC%E6%98%8E%E3%81%8C%E7%95%B0%E3%81%AA%E3%82%8B/StructureDefinition-jp-medication.html#profile)