### PR TITLE
内視鏡のマークダウンの内容修正

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-diagnosticreport-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-diagnosticreport-endoscopy-notes.md
@@ -31,17 +31,17 @@
 
 ## 注意事項
 
-### Text
+### text
 
 依頼情報や患者基本情報などを含むレポート全体のデータは、presentedForm要素に、base64で符号化されたバイナリデータとして格納される。
 そのため、主にレポートの見読性と検索性の向上を目的に、DiagnosticReportのDomainResourceの1つであるtext要素に、所見を中心としたhuman-readableな[narrative](https://www.hl7.org/fhir/R4/narrative.html)データを格納することを推奨する。
 (レポートの詳細はpresentedForm要素に格納されるレポート本体での確認を前提とする)
 
-### Category
+### category
 
 [JP Core Diagnostic Report Category ValueSet][JP_DiagnosticReportCategory_VS]の中から"Endoscopy"を表すLOINC Part Codeである`LP7796-8`を指定する。
 
-### Code
+### code
 
 [JP Core Document Codes Endoscopy ValueSet][JP_DocumentCodes_Endoscopy_VS] の中から適切な内視鏡分野の報告書のコードを指定する。より粒度の細かい報告書のコードを選ぶこと。
  - 例：上部消化管内視鏡報告書：`18751-8`
@@ -72,10 +72,10 @@
 
 | コンフォーマンス | パラメータ | 型 | 説明 | 表現型 |　例　|
 | --- | --- | --- | --- | --- | --- |
-| MAY | based-on | reference | オーダ情報への参照 | DiagnosticReport.basedOn ([ServiceRequest](https://hl7.org/fhir/R4/servicerequest.html)) | `GET [base]/DiagnosticReport?ServiceRequest/12345` |
+| MAY | based-on | reference | オーダ情報への参照 | DiagnosticReport.basedOn ([ServiceRequest](https://hl7.org/fhir/R4/servicerequest.html)) | `GET [base]/DiagnosticReport?based-on=ServiceRequest/12345` |
 | MAY | category | token | レポート種別 | DiagnosticReport.category ([JP Core DiagnosticReport Category ValueSet][JP_DiagnosticReportCategory_VS]) (デフォルト：[LP7796-8](https://loinc.org/LP7796-8/)) | `GET [base]/DiagnosticReport?category=LP7796-8` |
 | MAY | code | token | レポート全体を示すコード | DiagnosticReport.code ([JP Core DocumentCodes Endoscopy ValueSet][JP_DocumentCodes_Endoscopy_VS])  | `GET [base]/DiagnosticReport?code=18751-8` |
-| MAY | conclusionCode | token | 内視鏡診断レポートの要約結論 | DiagnosticReport.conclusionCode ([JP Core Conclusion Code JED ValueSet][JP_ConclusionCodesJed_VS])  | `GET [base]/DiagnosticReport?conclusionCode/Z2B32104` |
+| MAY | conclusionCode | token | 内視鏡診断レポートの要約結論 | DiagnosticReport.conclusionCode ([JP Core Conclusion Code JED ValueSet][JP_ConclusionCodesJed_VS])  | `GET [base]/DiagnosticReport?conclusionCode=Z2B32104` |
 
 
 なお、検索パラメータは複合的に利用できる。詳細は[Search - Chained parameters](https://www.hl7.org/fhir/R4/search.html#chaining)を参照すること。
@@ -109,4 +109,3 @@ GET [base]/DiagnosticReport?patient=123&category=LP7796-8
 
 {% include markdown-link-references.md %}
 {% include external-link-reference.md %}
-

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
@@ -31,9 +31,9 @@ ImagingStudyリソースは、次の要素を持たなければならない。(*
 
 ## 注意事項
 
-### Mappings
+### マッピング
 
-ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDICOM tagのマッピングについては[ Resource ImagingStudy - Mappings - DICOM Tag Mapping](https://hl7.org/fhir/R4/imagingstudy-mappings.html#dicom)を参照すること。
+ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDICOM tagのマッピングについては[Resource ImagingStudy - Mappings - DICOM Tag Mapping](https://hl7.org/fhir/R4/imagingstudy-mappings.html#dicom)を参照すること。
 
 ### reasonCode
 消化器内視鏡検査のDICOMフォーマットのデータを扱う際、ImagingStudy.reasonCodeには[JP Core ReasonCode JED ValueSet][JP_ReasonCodesJed_VS]をbindした。これは [日本消化器内視鏡学会](https://www.jges.net/)が推進する[JED (Japan Endoscopy Database) Project](https://jedproject.jges.net/)で定義されている[JED用語集](https://jedproject.jges.net/about/terms-about/)のコード集であり、このうち、基本用語集の"検査目的"、"治療目的"のコード値を設定することを強く推奨する。
@@ -73,4 +73,3 @@ ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDI
 
 {% include markdown-link-references.md %}
 {% include external-link-reference.md %}
-


### PR DESCRIPTION
## 修正内容
- 「注意事項」のセクションの中のサブセクションの見出しの要素名をcamel形式に統一 
　　(text, code, categoryがそれぞれ先頭が大文字だったのを是正)
- ImagingStudyの「注意事項」セクションの中の「Mappings」サブセクションの見出しを
　「マッピング」に変更 (要素名でないため混乱せぬよう日本語化)
- DiagnosticReport Endoscopyの、SearchParameter一覧にて、以下のURL書式を修正
  - based-on
  - conclusionCode

## Merge依頼先
<!-- (SGW[1-6] もしくは アカウント名) -->
<!-- 個人を指定するにはあわせてReviewersに設定すること-->
@findex-miyakawa 

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->

## 関連ISSUE
<!--fixed #999と記述するとマージ時に対象Issueが自動的にCloseします-->
fixed #510 

## 補足
