### PR TITLE
JP_MedicationRequest, _Injectionからpreparationを削除する

### DIFF
--- a/input/fsh/profiles/JP_MedicationRequest.fsh
+++ b/input/fsh/profiles/JP_MedicationRequest.fsh
@@ -10,7 +10,6 @@ Parent: MedicationRequest
 Id: jp-medicationrequest
 Title: "JP Core MedicationRequest Profile"
 Description: "このプロファイルはMedicationRequestリソースに対して、内服・外用薬剤処方のデータを送受信するための基礎となる制約と拡張を定めたものである。"
-* extension contains JP_MedicationDispense_Preparation named preparation ..*
 * ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest"
 * ^status = #active
 * ^date = "2022-10-31"
@@ -237,7 +236,6 @@ Parent: MedicationRequest
 Id: jp-medicationrequest-injection
 Title: "JP Core MedicationRequest Injection Profile"
 Description: "このプロファイルはMedicationRequestリソースに対して、注射薬剤処方のデータを送受信するための基礎となる制約と拡張を定めたものである。"
-* extension contains JP_MedicationDispense_Preparation named preparation ..*
 * ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_MedicationRequest_Injection"
 * ^status = #active
 * ^date = "2022-10-31"

--- a/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationrequest-injection-notes.md
@@ -20,7 +20,6 @@ JP Core MedicationRequest Injectionプロファイルで使用される拡張は
 
 |拡張|説明|定義|値型|
 |:----|:----|:----|:----|
-|調剤結果|薬剤単位の調剤結果|[JP_MedicationDispense_Preparation]|CodeableConcept|
 |RP内薬剤番号|RP内の薬剤の連番を格納する拡張<br/>《medicationReference配下》|[JP_Medication_Ingredient_DrugNo]|integer|
 |力価区分|投与量が製剤単位か成分単位かを格納する拡張<br/>《medicationReference配下》|[JP_Medication_IngredientStrength_StrengthType]|CodeableConcept|
 |用法コメント|用法コメントを格納するための拡張<br/>《dosageInstruction配下》|[JP_MedicationDosage_DosageComment]|CodeableConcept/String|

--- a/input/intro-notes/StructureDefinition-jp-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-medicationrequest-notes.md
@@ -18,7 +18,6 @@ JP Core MedicationRequest プロファイルで使用される拡張は次の通
 
 |拡張|説明|定義|値型|
 |:----|:----|:----|:----|
-|調剤結果|薬剤単位の調剤結果|[JP_MedicationDispense_Preparation]|CodeableConcept|
 |服用開始日|服用開始日を格納する拡張<br/>《dosageInstruction配下》|[JP_MedicationDosage_PeriodOfUse]|Period|
 |実服用日数|実服用日数を格納する拡張<br/>《dosageInstruction配下》|[JP_MedicationDosage_UsageDuration]|Duration|
 |調剤指示|薬剤単位の調剤指示を現するための拡張|[JP_MedicationRequest_DispenseRequest_InstructionForDispense]|CodeableConcept/string|


### PR DESCRIPTION
## 修正内容
JP_MedicationRequest, JP_MedicationRequest_Injectionに間違って preparation 拡張が残っていたため削除する

## Merge依頼先
SWG4-5
@skoba 

## レビュー観点
修正内容が正しくProfileとMDに反映されているか


## 関連ISSUE

## 補足
