### PR TITLE
series.modalityに関する検索について記述の見直しを行った

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,7 +16,7 @@ env:
   
 jobs:
   turn:
-    runs-on: ubuntu-latest
+    runs-on: LargerRunnerGroupforJPCore
     strategy:
       matrix:
         ruby-version: ['3.0']

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -99,6 +99,7 @@ jobs:
         mkdir input-cache
         mv publisher.jar ./input-cache/publisher.jar
         unset DISPLAY
+        # java  -Xmx4G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
         java  -Xmx4G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
         mv ./input/landing_page/_index.yml ./output/
 

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,7 +16,7 @@ env:
   
 jobs:
   turn:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby-version: ['3.0']
@@ -100,7 +100,7 @@ jobs:
         mv publisher.jar ./input-cache/publisher.jar
         unset DISPLAY
         # java  -Xmx4G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
-        java -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
+        java  -Xmx6G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
         mv ./input/landing_page/_index.yml ./output/
 
     - name: STEP1 = ssh key generate  for copying all IG files to public JAMI WG Web site 

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,7 +16,8 @@ env:
   
 jobs:
   turn:
-    runs-on: LargerRunnerGroupforJPCore
+    runs-on:
+      group: LargerRunnerGroupforJPCore
     strategy:
       matrix:
         ruby-version: ['3.0']

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,8 +16,7 @@ env:
   
 jobs:
   turn:
-    runs-on:
-      group: LargerRunnerGroupforJPCore
+    runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
         ruby-version: ['3.0']
@@ -101,7 +100,7 @@ jobs:
         mv publisher.jar ./input-cache/publisher.jar
         unset DISPLAY
         # java  -Xmx4G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
-        java  -Xmx4G -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
+        java -Djava.awt.headless=true -jar ./input-cache/publisher.jar -ig ig.ini -tx https://tx.jpfhir.jp:8081
         mv ./input/landing_page/_index.yml ./output/
 
     - name: STEP1 = ssh key generate  for copying all IG files to public JAMI WG Web site 

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
@@ -48,11 +48,9 @@ ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDI
 | コンフォーマンス | パラメータ    | 型     | 例          |
 | -------------| ----- | ------ | ----- |
 | SHOULD | patient | reference | `GET [base]/ImagingStudy?patient=123` |
-| MAY | patient, modality | reference, token | `GET [base]/ImagingStudy?patient=123&modality=ES` |
-| SHOULD | patient, series.modality | reference, token | `GET [base]/ImagingStudy?patient=123&series.modality=ES` |
+| SHOULD | patient, modality | reference, token | `GET [base]/ImagingStudy?patient=123&modality=ES` |
 | SHOULD | patient,started | reference, date | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-25` |
-| MAY | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=ES` |
-| SHOULD | patient, started, series.modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&series.modality=ES` |
+| SHOULD | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=ES` |
 
 なお、modalityは値が入っていない可能性があるため、モダリティを内視鏡に限定して検索する場合には、series.modalityを用いた方が確実である。
 

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
@@ -53,6 +53,7 @@ ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDI
 | SHOULD | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=ES` |
 
 なお検索パラメターmodalityは[定義済み検索パラメーター](https://www.hl7.org/fhir/R4/searchparameter-registry.html)にseries.modalityを対象として定義されているため、ImagingStudy.modalityを対象としていないことに注意すること。
+またImagingStudy.modalityには値が入っていない可能性がある点にも留意すること。
 
 #### 操作詳細
 

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
@@ -52,8 +52,7 @@ ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDI
 | SHOULD | patient,started | reference, date | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-25` |
 | SHOULD | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=ES` |
 
-なお、modalityは値が入っていない可能性があるため、モダリティを内視鏡に限定して検索する場合には、series.modalityを用いた方が確実である。
-
+なお、ImagingStudyはmodalityを検索対象とする場合、標準でseries.modalityを検索する仕様となっている。modalityエレメントはDICOMのstudyのmodalityに相当するものであるため、内容が含まれていないことが想定されるため、標準の検索対象でない点に注意すること。
 
 #### 操作詳細
 

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-endoscopy-notes.md
@@ -52,7 +52,7 @@ ImagingStudyはDICOM tagとの対応が重要である。各エレメントとDI
 | SHOULD | patient,started | reference, date | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-25` |
 | SHOULD | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=ES` |
 
-なお、ImagingStudyはmodalityを検索対象とする場合、標準でseries.modalityを検索する仕様となっている。modalityエレメントはDICOMのstudyのmodalityに相当するものであるため、内容が含まれていないことが想定されるため、標準の検索対象でない点に注意すること。
+なお検索パラメターmodalityは[定義済み検索パラメーター](https://www.hl7.org/fhir/R4/searchparameter-registry.html)にseries.modalityを対象として定義されているため、ImagingStudy.modalityを対象としていないことに注意すること。
 
 #### 操作詳細
 

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-radiology-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-radiology-notes.md
@@ -47,12 +47,11 @@ BodySite等でDICOMでmappingされているSNOMED-CTをCodeSystemとして利�
 | ---------------- | ------------- | ------ | ------------------------------------------------------------ |
 | SHOULD | identifier | token | `GET [base]/ImagingStudy?identifier=urn:oid:2.16.124.999999.9999.1154777499.30246.19789.3503430045` |
 | SHOULD | patient | reference | `GET [base]/ImagingStudy?patient=123` |
-| MAY | patient,modality | reference,token | `GET [base]/ImagingStudy?patient=123&modality=CT` |
-| SHOULD | patient, series.modality | reference, token | `GET [base]/ImagingStudy?patient=123&series.modality=CT` |
+| SHOULD | patient,modality | reference,token | `GET [base]/ImagingStudy?patient=123&modality=CT` |
 | SHOULD | patient,bodysite | reference,token | `GET [base]/ImagingStudy?patient=123&bodysite=T-15460` |
 | SHOULD | patient,started | reference,date | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-25` |
-| SHOULD | patient,started,series.modality,bodysite | reference,date,token,token  | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&series.modality=CT&bodysite=T-15460` |
-| SHOULD | patient, started, series.modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&series.modality=CT` |
+| SHOULD | patient,started,modality,bodysite | reference,date,token,token  | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=CT&bodysite=T-15460` |
+| SHOULD | patient, started, modality | reference, date, token | `GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=CT` |
 | SHOULD | encounter | reference  | `GET [base]/ImagingStudy?encounter=Encounter/456` |
 
 #### 操作詳細
@@ -75,13 +74,14 @@ GET [base]/ImagingStudy?patient={reference}
 ```
 GET [base]/ImagingStudy?patient=123
 ```
-1. モダリティ中心の検索：対象患者（= Patientリソース）と撮影に使用されたモダリティを条件とした検索をサポートすることが望ましい （studyのモダリティはDICOMで必須で無くseriesのモダリティが必須のため、以下の例はseries.modalityを使用。FHIR JP Coreではseries.modalityに設定されているモダリティ情報をmodalityに列挙することを想定しており、その場合modalityを検索パラメータとして利用してよい（**MAY**））  
+1. モダリティ中心の検索：対象患者（= Patientリソース）と撮影に使用されたモダリティを条件とした検索をサポートすることが望ましい  
+なお検索パラメターmodalityは[定義済み検索パラメーター](https://www.hl7.org/fhir/R4/searchparameter-registry.html)にseries.modalityを対象として定義されているため、ImagingStudy.modalityを対象としていないことに注意すること  
 ```
-GET [base]/ImagingStudy?patient={reference}&series.modality={token}
+GET [base]/ImagingStudy?patient={reference}&modality={token}
 ```
 例：
 ```
-GET [base]/ImagingStudy?patient=123&series.modality=CT
+GET [base]/ImagingStudy?patient=123&modality=CT
 ```
 1. 部位中心の検索：対象患者（= Patientリソース）と撮影の対象となった撮影部位を条件とした検索をサポートすることが望ましい  
 ```
@@ -108,12 +108,13 @@ GET [base]/ImagingStudy?patient={reference}&started={date}
 GET [base]/ImagingStudy?patient=123&started=eq2021-06-25
 ```
 1. 複数の条件を組み合わせた検索：対象患者（= Patientリソース）、撮影の日時、撮影に使用されたモダリティ、撮影の対象となった撮影部位を条件とした検索をサポートすることが望ましい  
+なお検索パラメターmodalityは[定義済み検索パラメーター](https://www.hl7.org/fhir/R4/searchparameter-registry.html)にseries.modalityを対象として定義されているため、ImagingStudy.modalityを対象としていないことに注意すること  
 ```
-GET [base]/ImagingStudy?patient={reference}&started={date}&series.modality={token}&bodysite={token}
+GET [base]/ImagingStudy?patient={reference}&started={date}&modality={token}&bodysite={token}
 ```
 例：
 ```
-GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&series.modality=CT&bodysite=T-15460
+GET [base]/ImagingStudy?patient=123&started=eq2021-06-18&modality=CT&bodysite=T-15460
 ```
 1. 来院情報中心の検索：来院情報（= Encounterリソース）を条件とした検索をサポートすることが望ましい  
 ```


### PR DESCRIPTION
## 修正内容
series.modalityに関する検索について記述の見直しを行った

## Merge依頼先
@HERMITRION 

## レビュー観点
ImagingStudyのmodalityの検索ですが、
https://www.hl7.org/fhir/R4/searchparameter-registry.html
のImagingStudy-modalityにヒットする列にあるのですが、既に定義済みの検索パラメーターにmodalityとして登録されており、その対象はSeries.modalityになっています。

複雑なのですが、Imaging.modalityを検索するには、別途FHIR.PATH等で指摘するか、あらたにSearchParameterを作成してjp-Imagingstudy-modality等を定義することになりそうです。

ImagingStudy.modalityについては重要な項目ではないため、これに合わせて修正を行いました。

## 関連ISSUE
<!--fixed #999と記述するとマージ時に対象Issueが自動的にCloseします-->

## 補足
