### PR TITLE
JP Core Observation LabResult ProfileのExampleを修正（深川さん修正分）

### DIFF
--- a/input/fsh/examples/JP_Observation_LabResult_Example.fsh
+++ b/input/fsh/examples/JP_Observation_LabResult_Example.fsh
@@ -1,23 +1,23 @@
 Instance: jp-observation-labresult-example-1
 InstanceOf: JP_Observation_LabResult
-Title: "JP Core Observation LabResult Example 検体検査（尿）"
-Description: "検体検査（尿）"
+Title: "JP Core Observation LabResult Example 検体検査（尿酸）"
+Description: "検体検査（尿酸）"
 Usage: #example
 * contained[0] = jp-servicerequest-example-1
 * category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory
 * basedOn = Reference(ServiceRequest/jp-servicerequest-example-1)
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#05104 "尿酸"
 * code.coding[+] = $JP_ObservationLabResultCode_CS#3C020000002327101
-* code.text = "検査項目コード"
-* interpretation.coding = http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation#L "Low"
-* interpretation.text = "HLマーク"
-* effectiveDateTime = "2021-10-19T17:39:00+09:00"
+* code.text = "尿酸"
+* interpretation.coding = http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation#H "High"
+* interpretation.text = "H"
+* effectiveDateTime = "2021-10-19T02:20:00+09:00"
 * status = #final
-* referenceRange.low.value = 3.7
-* referenceRange.high.value = 7.8
+* referenceRange.low.value = 2.1
+* referenceRange.high.value = 7.0
 * referenceRange.type.coding = http://terminology.hl7.org/CodeSystem/referencerange-meaning#normal "Normal Range"
 * valueQuantity.unit = #mg/dL
-* valueQuantity.value = 3.5
+* valueQuantity.value = 8.5
 * subject = Reference(Patient/jp-patient-example-1)
 * performer = Reference(jp-practitioner-example-female-1)
 * specimen = Reference(Specimen/jp-specimen-example-1)
@@ -29,10 +29,10 @@ Usage: #inline
 * status = #active
 * intent = #original-order
 * code = http://abc-hospital.local/fhir/ObservationOrder/localcode#12345678
-* code.text = "尿検査"
+* code.text = "生化学検査"
 * subject = Reference(Patient/jp-patient-example-1)
 * encounter = Reference(Encounter/jp-encounter-example-1)
-* occurrenceDateTime = "2021-10-10T17:39:00+09:00"
+* occurrenceDateTime = "2021-10-19T01:15:00+09:00"
 * requester = Reference(Practitioner/jp-practitioner-example-female-1)
 * performer = Reference(Practitioner/jp-practitioner-example-male-2)
 

--- a/input/intro-notes/StructureDefinition-jp-observation-common-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-observation-common-notes.md
@@ -318,7 +318,7 @@ Observation.hasMember（検査保持メンバ）と Observation.derivedFrom（�
     "display": "尿酸(UA)"
    }
   ],
-  "text": "検査項目コード"
+  "text": "尿酸"
  }
 ```
 


### PR DESCRIPTION
## 修正内容
本WGの深川さんによる以下の修正分です

- containedのtext☑生化学検査 ※”尿検査"ではないので修正
- codeのtext☑尿酸 "検査項目コード"ではないので修正
- interpretationのtext☑H 高値のほうが疾患をイメージしやすいので修正 + coding部分も高値へ
- referenceRangeのlow/high☑2.1-7 日本的な基準値に修正（人間ドック学会参照）
- valueQuantityのvalue☑8.5 高値のほうが疾患をイメージしやすいので修正
- occurenceDateTimeとeffectiveDateTime☑2021-10-19T01:15:00+09:00,2021-10-19T02:20:00+09:00 ※自然な日本時間に修正

## Merge依頼先
@findex-miyakawa 

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->
修正先のブランチが間違っていないか
