### PR TITLE
fixed typo:尿 -> 尿酸

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-observation-labresult-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-observation-labresult-notes.md
@@ -119,6 +119,6 @@ ObservationリソースのOperation一覧の定義はユースケースに依存
 
 ### サンプル
 
-* [**検体検査（尿）**][jp-observation-labresult-example-1]
+* [**検体検査（尿酸）**][jp-observation-labresult-example-1]
 
 {% include markdown-link-references.md %}


### PR DESCRIPTION
## 修正内容
検体検査結果の例として「尿」と書かれていましたが、リンク先は「尿酸」なので修正しました。

## Merge依頼先
SWG2か宮川さん

## レビュー観点
誤字の確認とmerge先をご検討ください

