### PR TITLE
GitHub Actionsで使っているactionを更新

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -166,7 +166,7 @@ jobs:
 
     - name: STEP3 = Deploy Implementation Guide
       if: success()
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
         external_repository: jami-fhir-jp-wg/jp-core-v1xpages

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: ['3.0']
     environment: SSH_PORT_JPFHIR  # JAMI WG アップロードサイトに関するアクセス情報の環境名
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Extract branch name
       run: |

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -54,8 +54,9 @@ jobs:
         _output-file: input/landing_page/_index.yml
 
     - name: Setup npm
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with: 
+        cache: npm
         check-latest: true
 
     - name: Setup Sushi

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -56,7 +56,6 @@ jobs:
     - name: Setup npm
       uses: actions/setup-node@v4
       with: 
-        cache: npm
         check-latest: true
 
     - name: Setup Sushi

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -26,18 +26,18 @@ jobs:
     - name: Extract branch name
       run: |
         if ["${{ github.event.pull_request.head.ref }}" == ""]; then
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch_group;]$(echo ${GITHUB_REF#refs/heads/})"
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "branch_group=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         else
-          echo "##[set-output name=branch;]$(echo ${{ github.event.pull_request.head.ref }})"
-          echo "##[set-output name=branch_group;]$(echo 'pullrequest')"
+          echo "branch=$(echo ${{ github.event.pull_request.head.ref }})" >> $GITHUB_OUTPUT
+          echo "branch_group=$(echo 'pullrequest')" >> $GITHUB_OUTPUT
         fi
       id: extract_branch
     
     - name: Extract last commit date
       shell: bash
       run: |
-        echo "##[set-output name=date;]$(git log -1 --format="%at" | xargs -I{} date -d @{})"   
+        echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
       id: extract_date
 
     - uses: bluwy/substitute-string-action@v1

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -76,14 +76,14 @@ jobs:
         file: publisher.jar
     
     - name: Download the file
-      uses: suisei-cn/actions-download-file@v1.4.0
+      uses: suisei-cn/actions-download-file@v1.6.0
       id: downloadfile1
       with:
         url: "https://jpfhir.jp/fhir/fhir_dotFHIR_packages.tgz"
         target: .
 
     - name: Download the file
-      uses: suisei-cn/actions-download-file@v1.4.0
+      uses: suisei-cn/actions-download-file@v1.6.0
       id: downloadfile2
       with:
         url: "https://jpfhir.jp/fhir/core/terminology/jpfhir-terminology.r4-1.1.1.tgz"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: ['3.0']
     environment: SSH_PORT_JPFHIR  # JAMI WG アップロードサイトに関するアクセス情報の環境名
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Extract branch name
       run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -164,7 +164,7 @@ jobs:
 
     - name: STEP3 = Deploy Implementation Guide
       if: success()
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         personal_token: ${{ secrets.PERSONAL_TOKEN }}
         external_repository: jami-fhir-jp-wg/jp-core-v1xpages

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,18 +26,18 @@ jobs:
     - name: Extract branch name
       run: |
         if ["${{ github.event.pull_request.head.ref }}" == ""]; then
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-          echo "##[set-output name=branch_group;]$(echo ${GITHUB_REF#refs/heads/})"
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+          echo "branch_group=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         else
-          echo "##[set-output name=branch;]$(echo ${{ github.event.pull_request.head.ref }})"
-          echo "##[set-output name=branch_group;]$(echo 'pullrequest')"
+          echo "branch$(echo ${{ github.event.pull_request.head.ref }})" >> $GITHUB_OUTPUT
+          echo "branch_group$(echo 'pullrequest')" >> $GITHUB_OUTPUT
         fi
       id: extract_branch
     
     - name: Extract last commit date
       shell: bash
       run: |
-        echo "##[set-output name=date;]$(git log -1 --format="%at" | xargs -I{} date -d @{})"   
+        echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
       id: extract_date
 
     - uses: bluwy/substitute-string-action@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -54,7 +54,7 @@ jobs:
         _output-file: input/landing_page/_index.yml
 
     - name: Setup npm
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with: 
         check-latest: true
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,14 +75,14 @@ jobs:
         file: publisher.jar
         
     - name: Download the file
-      uses: suisei-cn/actions-download-file@v1.4.0
+      uses: suisei-cn/actions-download-file@v1.6.0
       id: downloadfile1
       with:
         url: "https://jpfhir.jp/fhir/fhir_dotFHIR_packages.tgz"
         target: .
   
     - name: Download the file
-      uses: suisei-cn/actions-download-file@v1.4.0
+      uses: suisei-cn/actions-download-file@v1.6.0
       id: downloadfile2
       with:
         url: "https://jpfhir.jp/fhir/core/terminology/jpfhir-terminology.r4-1.1.1.tgz"


### PR DESCRIPTION
第15回医療オープンソースソフトウェア協議会セミナーに参加させていただいたものです。
リポジトリを拝見して、contributeできそうなところを見かけたためPR送らせていただいています。

## 修正内容

GitHub Actionsで使っているactionが古く、Node 16を使っていることに起因する警告が出ておりましたので、各actionsを更新しています。更新にはbreaking changeがないことを確認済みです。

また [`set-output` は2022年から非推奨となっています](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)ので、`$GITHUB_OUTPUT` で置き換えたほうが良いのではと思いました。

## Merge依頼先
<!-- (SGW[1-6] もしくは アカウント名) -->
<!-- 個人を指定するにはあわせてReviewersに設定すること-->

不明です。お手数おかけしますがアサインいただけると助かります。

## レビュー観点
<!--特にレビューをしてほしい点について記述する-->

forkしたリポジトリではSTEP1以降のstepが動作しないため、動作確認は不十分な状態です。
大きな問題はないはずですが、一度こちらのPR内でworkflowを実行いただくほうが安全だと思います（権限をお持ちの方に実行いただければSecretsにアクセス可能なはず）。

## 関連ISSUE
<!--fixed #999と記述するとマージ時に対象Issueが自動的にCloseします-->

該当なし。

## 補足

特にありません。よろしくお願いいたします。