### PR TITLE
medicationReferenceにdefinitionを追加

### DIFF
--- a/input/fsh/profiles/JP_MedicationAdministration.fsh
+++ b/input/fsh/profiles/JP_MedicationAdministration.fsh
@@ -219,7 +219,7 @@ Description: "このプロファイルはMedicationAdministrationリソースに
     JP_MedicationAdministration_UncategorizedComment named uncategorizedComment ..*
 * medication[x] only Reference(Medication)
 * medicationReference only Reference(JP_Medication)
-
+* medicationReference ^definition = "医薬品の識別情報は必須でありmedicationReference.referenceが必ず存在しなければならない、JP Coreでは注射の医薬品情報は単一薬剤の場合も Medicationリソースとして記述し、medicationCodeableConceptは使用しない。参照するMedicationリソースは、MedicationRequest.contained属性に内包することが望ましいが、外部参照としても良い。"
 
 * dosage.extension contains
     JP_MedicationDosage_DosageComment named dosageComment ..* and

--- a/input/fsh/profiles/JP_MedicationRequest.fsh
+++ b/input/fsh/profiles/JP_MedicationRequest.fsh
@@ -328,6 +328,7 @@ HL7 FHIRではvalue setとして http://terminology.hl7.org/CodeSystem/medicatio
 また、処方を発行した医療機関内でのデータ利用のために、医療機関固有コード体系によるコード（ハウスコード、ローカルコード）の記述を含めてもよいが、その場合でも上述したいずれかの標準コードを同時に記述することが必要である。"
 * medication[x] only Reference(Medication)
 * medicationReference only Reference(JP_Medication)
+* medicationReference ^definition = "医薬品の識別情報は必須でありmedicationReference.referenceが必ず存在しなければならない、JP Coreでは注射の医薬品情報は単一薬剤の場合も Medicationリソースとして記述し、medicationCodeableConceptは使用しない。参照するMedicationリソースは、MedicationRequest.contained属性に内包することが望ましいが、外部参照としても良い。"
 * priority ^short = "オーダの優先度"
 * priority ^definition = "このMedicationRequestオーダの優先度。他のオーダと比較して表現される。"
 * priority ^comment = "FHIRでは文字列の大きさが1MBを超えてはならない(SHALL NOT)。"

--- a/input/fsh/profiles/JP_MedicationStatement.fsh
+++ b/input/fsh/profiles/JP_MedicationStatement.fsh
@@ -135,6 +135,7 @@ Description: "このProfileは服薬状況を示すものであり，診療情�
 * medication[x] only Reference(Medication)
 
 * medicationReference only Reference(JP_Medication)
+* medicationReference ^definition = "医薬品の識別情報は必須でありmedicationReference.referenceが必ず存在しなければならない、JP Coreでは注射の医薬品情報は単一薬剤の場合も Medicationリソースとして記述し、medicationCodeableConceptは使用しない。参照するMedicationリソースは、MedicationRequest.contained属性に内包することが望ましいが、外部参照としても良い。"
 
 * subject only Reference(JP_Patient)
 * subject ^short = "処方箋が発行された患者に対する参照"


### PR DESCRIPTION
## 修正内容

#568 に対応するためmedicationReferenceに下記definitionを追加。

``
医薬品の識別情報は必須でありmedicationReference.referenceが必ず存在しなければならない、JP Coreでは注射の医薬品情報は単一薬剤の場合も Medicationリソースとして記述し、medicationCodeableConceptは使用しない。参照するMedicationリソースは、MedicationRequest.contained属性に内包することが望ましいが、外部参照としても良い。
``

## Merge依頼先
SWG45

## レビュー観点
definitionのつける一。

## 関連ISSUE

Fixed #568

## 補足
