### PR TITLE
url エラーの修正

### DIFF
--- a/input/fsh/profiles/JP_Observation_Radiology_Impression.fsh
+++ b/input/fsh/profiles/JP_Observation_Radiology_Impression.fsh
@@ -6,7 +6,7 @@ Parent: Observation
 Id: jp-observation-radiology-impression
 Title: "JP Core Observation Radiology Impression Profile"
 Description: "このプロファイルはDiagnosticReport_Radiologyリソースに関連する画像診断報告書の「インプレッション」データを送受信するための共通の制約と拡張を定めたものである"
-* ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Observation_Radiology_impression"
+* ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Observation_Radiology_Impression"
 * ^status = #active
 * ^date = "2024-07-18"
 * . ^short = "画像診断レポートの結論（インプレッション）"

--- a/input/fsh/terminologies/JP_DICOMModality_VS.fsh
+++ b/input/fsh/terminologies/JP_DICOMModality_VS.fsh
@@ -1,5 +1,5 @@
 ValueSet: JP_DICOMModality_VS
-Id: jp-DICOMmodality-vs
+Id: jp-dicommodality-vs
 Title: "JP Core DICOM Modality ValueSet"
 Description: "放射線モダリテに対する 値セット"
 * ^url = $JP_DICOMModality_VS

--- a/input/fsh/terminologies/JP_ObservationRadiologyCode_VS.fsh
+++ b/input/fsh/terminologies/JP_ObservationRadiologyCode_VS.fsh
@@ -1,5 +1,5 @@
 ValueSet: JP_ObservationRadiologyCode_VS
-Id: jp-ObservationRadiologyCode-vs
+Id: jp-observation-radiology-code-vs
 Title: "JP Core Observation Radiology Code ValueSet"
 Description: "Observation（放射線）コードで使用する項目値セット。LOINCのFindings、Impressionに相当する"
 * ^url = $JP_ObservationRadiologyCode_VS

--- a/input/includes/markdown-link-references.md
+++ b/input/includes/markdown-link-references.md
@@ -150,7 +150,7 @@
 [JP_ConclusionCodesJed_VS]: ValueSet-jp-conclusion-codes-jed-vs.html
 [JP_ConditionSeverity_VS]: ValueSet-jp-condition-severity-vs.html
 [JP_DiagnosticReportCategory_VS]: ValueSet-jp-diagnosticreportcategory-vs.html
-[JP_DICOMModality_VS]: ValueSet-jp-DICOMmodality-vs.html
+[JP_DICOMModality_VS]: ValueSet-jp-dicommodality-vs.html
 [JP_DocumentCodes_DiagnosticReport_VS]: ValueSet-jp-documentcodes-diagnosticreport-vs.html
 [JP_DocumentCodes_Endoscopy_VS]: ValueSet-jp-documentcodes-endoscopy-vs.html
 [JP_MedicalLicenseCertificate_VS]: ValueSet-jp-medicallicensecertificate-vs.html

--- a/input/intro-notes/StructureDefinition-jp-diagnosticreport-radiology-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-diagnosticreport-radiology-notes.md
@@ -142,7 +142,7 @@ Conclusionやコード化された診断結果は各々がレポートを構成�
 | SHOULD | category | token | レポート種別 | DiagnosticReport.category ([ValueSet]()) <br/> 第1コードは LP29684-5 (Radiology 固定) <br/>第2コード以下は複数のコードを許容し、DICOMモダリティコードが格納される | GET [base]/DiagnosticReport?category=LP29684-5&category=CT |
 | SHOULD | code | token | レポート全体を示すコード | DiagnosticReport.code [LOINC 18748-4](https://loinc.org/18748-4/)(固定) | GET [base]/DiagnosticReport?code=18748-4 |
 | MAY | media | reference | キー画像への参照 | DiagnosticReport.media.link ([Media](https://www.hl7.org/fhir/R4/media.html)) | GET [base]/DiagnosticReport?media/12345 |
-| MAY | result | reference | 所見内容の検索 | 	DiagnosticReport.result ([Observation](JP_Observation_Radiology_Findigs)) | GET [base]/DiagnosticReport?result:Observation.valuestring:contains=肺癌 |
+| MAY | result | reference | 所見内容の検索 | 	DiagnosticReport.result ([Observation](JP_Observation_Radiology_Findings)) | GET [base]/DiagnosticReport?result:Observation.valuestring:contains=肺癌 |
 
 なお、検索パラメータは複合的に利用できる。詳細は[Search - Chained parameters](https://www.hl7.org/fhir/R4/search.html#chaining)を参照すること。
 

--- a/input/intro-notes/StructureDefinition-jp-diagnosticreport-radiology-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-diagnosticreport-radiology-notes.md
@@ -142,7 +142,7 @@ Conclusionやコード化された診断結果は各々がレポートを構成�
 | SHOULD | category | token | レポート種別 | DiagnosticReport.category ([ValueSet]()) <br/> 第1コードは LP29684-5 (Radiology 固定) <br/>第2コード以下は複数のコードを許容し、DICOMモダリティコードが格納される | GET [base]/DiagnosticReport?category=LP29684-5&category=CT |
 | SHOULD | code | token | レポート全体を示すコード | DiagnosticReport.code [LOINC 18748-4](https://loinc.org/18748-4/)(固定) | GET [base]/DiagnosticReport?code=18748-4 |
 | MAY | media | reference | キー画像への参照 | DiagnosticReport.media.link ([Media](https://www.hl7.org/fhir/R4/media.html)) | GET [base]/DiagnosticReport?media/12345 |
-| MAY | result | reference | 所見内容の検索 | 	DiagnosticReport.result ([Observation](JP_Observation_Radiology_Findings)) | GET [base]/DiagnosticReport?result:Observation.valuestring:contains=肺癌 |
+| MAY | result | reference | 所見内容の検索 | 	DiagnosticReport.result ([Observation][JP_Observation_Radiology_Findings]) | GET [base]/DiagnosticReport?result:Observation.valuestring:contains=肺癌 |
 
 なお、検索パラメータは複合的に利用できる。詳細は[Search - Chained parameters](https://www.hl7.org/fhir/R4/search.html#chaining)を参照すること。
 


### PR DESCRIPTION
## 修正内容
宮川さん指摘のエラーの修正

## Merge依頼先
SWG2

## レビュー観点
VS関連のurl修正および一部typoの修正

url表記の齟齬についてのエラーは残っていますが、VSのidとurlについて他のリソースと同様の命名規則で記述しているにも関わらずエラーが残ります。urlを小文字にしてidと合わせると解決する話と思いますが、swg45の守備範囲と思われますのでそのままにしてあります。

## 関連ISSUE
<!--fixed #999と記述するとマージ時に対象Issueが自動的にCloseします-->

## 補足
