### PR TITLE
modalityとstatusの検索パラメータの追加

### DIFF
--- a/input/fsh/profiles/JP_ImagingStudy_Endoscopy.fsh
+++ b/input/fsh/profiles/JP_ImagingStudy_Endoscopy.fsh
@@ -9,6 +9,7 @@ Description: "このプロファイルはImagingStudyリソースに対して、
 * ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_ImagingStudy_Endoscopy"
 * ^status = #active
 * ^date = "2023-10-31"
+* ^copyright = "Copyright FHIR Japanese implementation research working group in Japan Association of Medical Informatics (JAMI) 一般社団法人日本医療情報学会NeXEHRS課題研究会FHIR日本実装検討WG. DICOM® is the registered trademark of the National Electrical Manufacturers Association for its Standards publications relating to digital communications of medical information."
 * . ^short = "内視鏡を使用したDICOM画像検査に関する情報"
 * identifier MS
 * identifier ^short = "DICOM画像検査全体を一意に識別するためのID【詳細参照】"

--- a/input/fsh/profiles/JP_ImagingStudy_Radiology.fsh
+++ b/input/fsh/profiles/JP_ImagingStudy_Radiology.fsh
@@ -10,6 +10,7 @@ Description: "このプロファイルはImagingStudyリソースに対して、
 * ^status = #active
 * ^date = "2023-10-31"
 * . ^short = "DICOM画像検査で作成されたコンテンツの表現。スタディは一連のシリーズで構成され、各シリーズには、共通のコンテキストで取得または生成された一連のサービスオブジェクトペアインスタンス（SOPインスタンス-画像またはその他のデータ）が含まれる、シリーズは1つのモダリティ（X線、CT、MR、超音波など）のみだがスタディには複数の異なるモダリティのシリーズが含まれる場合がある"
+* ^copyright = "Copyright FHIR Japanese implementation research working group in Japan Association of Medical Informatics (JAMI) 一般社団法人日本医療情報学会NeXEHRS課題研究会FHIR日本実装検討WG. DICOM® is the registered trademark of the National Electrical Manufacturers Association for its Standards publications relating to digital communications of medical information."
 * identifier MS
 * identifier ^short = "スタディ全体の識別子"
 * identifier ^definition = "DICOMスタディインスタンスUIDやアクセッション番号などのImagingStudyの識別子。"
@@ -20,6 +21,7 @@ Description: "このプロファイルはImagingStudyリソースに対して、
 * status ^definition = "ImagingStudyの現在のステータス"
 * status ^comment = "不明(unknown)は「その他」を表すものではない。定義されたステータスの1つを適用する必要がある。不明(unknown)は、オーサリングシステムが現在のステータスを確認できない場合に使用される。  
 【JP-Core仕様】リソースの状態。"
+* modality from $JP_DICOMModality_VS (required)
 * modality ^short = "実際の取得モダリティーの場合、モダリティーの全シリーズ。対応するDICOM tag: (0008, 0061)"
 * modality ^definition = "実際の取得モダリティであるすべてのseries.modality値のリスト、つまりDICOMコンテキストグループ29（値セットOID 1.2.840.10008.6.1.19）の値。"
 * modality ^comment = "コードは、列挙型またはコードリストで、DICOMのモダリティコードを利用する。  
@@ -116,6 +118,7 @@ study階層のidentifierと同じ概念。(0020,000E)にseries固有のUIDが付
 * series.number ^comment = "32ビット数で表す。これより大きい値の場合は、10進数を使用する。  
 上記UIDとは別に、ユーザ（または装置）が自由に決められる番号。"
 * series.modality MS
+* series.modality from $JP_DICOMModality_VS (required)
 * series.modality ^short = "シリーズが取得されたモダリティ"
 * series.modality ^definition = "シリーズが取得されたモダリティー"
 * series.modality ^comment = "JP CoreではDICOMのモダリティコードを利用する。SNOMED CTは推奨しない。  

--- a/input/fsh/terminologies/JP_DICOMModality_VS.fsh
+++ b/input/fsh/terminologies/JP_DICOMModality_VS.fsh
@@ -6,6 +6,7 @@ Description: "放射線モダリテに対する 値セット"
 * ^status = #active
 * ^experimental = false
 * ^date = "2023-10-31"
+* ^copyright = "DICOM® is the registered trademark of the National Electrical Manufacturers Association for its Standards publications relating to digital communications of medical information. "
 
 * $dicom-ontology#AR "Autorefraction"
 //* $dicom-ontology#ASMT "Content Assessment Result"

--- a/input/intro-notes/StructureDefinition-jp-imagingstudy-radiology-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-imagingstudy-radiology-notes.md
@@ -42,11 +42,13 @@ BodySite等でDICOMでmappingされているSNOMED-CTをCodeSystemとして利�
 ### OperationおよびSearch Parameter 一覧
 
 #### Search Parameter一覧
-代表的な検索パラメータを示す。ここに例示されない複合検索が必要となることも想定されるため、ユースケースに応じ適宜拡張すること。
+代表的な検索パラメータを示す。ここに例示されない検索項目であっても HL7.org FHIR R4 で定義されている検索項目に加え、複合検索が必要となることも想定されるため、ユースケースに応じ適宜拡張すること。
 
 | コンフォーマンス | パラメータ    | 型     | 例                                                           |
 | ---------------- | ------------- | ------ | ------------------------------------------------------------ |
 | SHALL | identifier | token | `GET [base]/ImagingStudy?identifier=urn:oid:2.16.124.999999.9999.1154777499.30246.19789.3503430045` |
+| SHALL | status | token | `GET [base]/ImagingStudy?status=available`	|
+| SHOULD | modality, series.modality | token | `GET [base]/ImagingStudy?modality=CT` `GET [base]/ImagingStudy?series.modality=CT` |
 | SHOULD | patient | reference | `GET [base]/ImagingStudy?patient=123` |
 | SHOULD | patient,modality | reference,token | `GET [base]/ImagingStudy?patient=123&modality=CT` |
 | SHOULD | patient,bodysite | reference,token | `GET [base]/ImagingStudy?patient=123&bodysite=T-15460` |


### PR DESCRIPTION
## 修正内容
modalityとstatusの検索パラメータの追加

## Merge依頼先
SWG2

## レビュー観点
検索パラメータにmodalityの例を追加。また、statusはSHALLと思われるので追加。
他の検索パラメータは本家の定義を参照するように記述を追加

## 関連ISSUE
<!--fixed #999と記述するとマージ時に対象Issueが自動的にCloseします-->

## 補足
