### PR TITLE
categoryのslicingに対してのネーミングルールを統一化した。

### DIFF
--- a/_genonce.bat
+++ b/_genonce.bat
@@ -2,16 +2,24 @@
 SET publisher_jar=publisher.jar
 SET input_cache_path=%CD%\input-cache
 
-SET javaoption=-Duser.language=ja -Duser.country=JP -Djava.awt.headless=true
-@REM SET javaoption= -Xmx12G -Duser.language=ja -Duser.country=JP -Djava.awt.headless=true
+ECHO Checking internet connection...
+PING tx.fhir.org -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+ECHO We're offline...
 SET txoption=-tx n/a
+GOTO igpublish
+
+:isonline
+ECHO We're online
+SET txoption=
+
+:igpublish
 
 SET JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
 
 IF EXIST "%input_cache_path%\%publisher_jar%" (
-	JAVA -jar %javaoption% "%input_cache_path%\%publisher_jar%" -ig . %txoption% %*
+	JAVA -jar "%input_cache_path%\%publisher_jar%" -ig . %txoption% %*
 ) ELSE If exist "..\%publisher_jar%" (
-	JAVA -jar %javaoption% "..\%publisher_jar%" -ig . %txoption% %*
+	JAVA -jar "..\%publisher_jar%" -ig . %txoption% %*
 ) ELSE (
 	ECHO IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
 )

--- a/input/fsh/examples/JP_DiagnosticReportDentalOral_Example.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportDentalOral_Example.fsh
@@ -9,7 +9,7 @@ Usage: #example
 * identifier.system = "http://jpfhir.jp/fhir/core/IdSystem/resourceInstance-identifier"
 * identifier.value = "123456"
 * status = #final
-* category[dentaloral] = $Loinc_CS#LP31759-1 "歯科口腔"
+* category[first] = $Loinc_CS#LP31759-1 "歯科口腔"
 * code = $JP_DocumentCodes_CS#32453-3 "口腔診査報告書"
 * subject = Reference(Patient/jp-patient-example-1)
 * effectiveDateTime = "2022-10-01"

--- a/input/fsh/examples/JP_DiagnosticReportEndoscopy_Example_1.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportEndoscopy_Example_1.fsh
@@ -10,7 +10,7 @@ Usage: #example
 * identifier.system = "http://abc-hospital.local/fhir/identifier/endoscopy/report"
 * identifier.value = "123456"
 * status = #final
-* category[endoscopy] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $Loinc_CS#LP7796-8 "内視鏡"
 * code = $JP_DocumentCodes_CS#18751-8 "上部消化管内視鏡報告書"
 * subject = Reference(Patient/jp-patient-example-1) "山田 太郎"
 * effectiveDateTime = "2023-04-26"

--- a/input/fsh/examples/JP_DiagnosticReportEndoscopy_Example_2.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportEndoscopy_Example_2.fsh
@@ -10,7 +10,7 @@ Usage: #example
 * identifier.system = "http://abc-hospital.local/fhir/identifier/endoscopy/report"
 * identifier.value = "123456"
 * status = #final
-* category[endoscopy] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $Loinc_CS#LP7796-8 "内視鏡"
 * code = $JP_DocumentCodes_CS#18746-8 "下部消化管内視鏡報告書"
 * subject = Reference(Patient/jp-patient-example-1) "山田 太郎"
 * effectiveDateTime = "2024-07-03"

--- a/input/fsh/examples/JP_DiagnosticReportLabResult_Example.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportLabResult_Example.fsh
@@ -9,7 +9,7 @@ Usage: #example
 * status = #final
 * identifier.system = "http://abc-hospital.local/fhir/lab/reportid"
 * identifier.value = "5234342"
-* category[laboratory] = $Loinc_CS#LP29693-6 "検体検査"
+* category[first] = $Loinc_CS#LP29693-6 "検体検査"
 * code = $JP_DocumentCodes_CS#11502-2 "検体検査報告書"
 * subject = Reference(Patient/jp-patient-example-1)
 * encounter = Reference(Encounter/jp-encounter-example-1)
@@ -29,7 +29,7 @@ Instance: inner-observation-labresult-1
 InstanceOf: JP_Observation_LabResult
 Usage: #inline
 * status = #final
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#123 "ヘモグロビン"
 * code.coding[+] = $JP_ObservationLabResultCode_CS#2A990000001930953
 * code.text = "ヘモグロビン"
@@ -45,7 +45,7 @@ Instance: inner-observation-labresult-2
 InstanceOf: JP_Observation_LabResult
 Usage: #inline
 * status = #final
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#456 "赤血球数"
 * code.coding[+] = $JP_ObservationLabResultCode_CS#2A990000001992051
 * code.text = "赤血球数"
@@ -62,7 +62,7 @@ Instance: inner-observation-labresult-3
 InstanceOf: JP_Observation_LabResult
 Usage: #inline
 * status = #final
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#789 "ヘマトクリット"
 * code.coding[+] = $JP_ObservationLabResultCode_CS#2A990000001930954
 * code.text = "ヘマトクリット"
@@ -78,4 +78,3 @@ Usage: #inline
 * referenceRange.high.unit = "%"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * specimen = Reference(Specimen/jp-specimen-example-2)
-

--- a/input/fsh/examples/JP_DiagnosticReportMicrobiology_Example.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportMicrobiology_Example.fsh
@@ -41,7 +41,7 @@ Usage: #example
 * identifier.value = "1234567"
 * basedOn = Reference(ServiceRequest/jp-servicerequest-example-1)
 * status = #final
-* category[microbiology] = $Loinc_CS#LP7819-8 "微生物検査"
+* category[first] = $Loinc_CS#LP7819-8 "微生物検査"
 * code = $JP_DocumentCodes_CS#18725-2 "微生物学的検査報告書"
 * subject = Reference(Patient/jp-patient-example-1)
 * encounter = Reference(Encounter/jp-encounter-example-1)
@@ -69,9 +69,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6A010000006170449 "塗抹鏡検(一般細菌)_喀痰_グラム染色"
 * code.coding[+] = http://abc-hospital.local/fhir/Observation/localcode#6A0100000061704Z1 "塗抹鏡検(一般細菌)_喀痰_グラム染色_ユーザ定義1(白血球)"
 * code.text = "白血球"
@@ -84,9 +84,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6A010000006170449 "塗抹鏡検(一般細菌)_喀痰_グラム染色"
 * code.coding[+] = http://abc-hospital.local/fhir/Observation/localcode#6A0100000061704Z2 "塗抹鏡検(一般細菌)_喀痰_グラム染色_ユーザ定義2(上皮細胞)"
 * code.text = "上皮細胞"
@@ -99,9 +99,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6A010000006170449 "塗抹鏡検(一般細菌)_喀痰_グラム染色"
 * code.coding[+] = http://abc-hospital.local/fhir/Observation/localcode#6A0100000061704Z3 "塗抹鏡検(一般細菌)_喀痰_グラム染色_ユーザ定義3(グラム陽性球菌（GPC）)"
 * code.text = "グラム陽性球菌（GPC）"
@@ -114,9 +114,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#gram-stain "Gram stain"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6A010000006170449 "塗抹鏡検(一般細菌)_喀痰_グラム染色"
 * code.coding[+] = http://abc-hospital.local/fhir/Observation/localcode#6A0100000061704Z4 "塗抹鏡検(一般細菌)_喀痰_グラム染色_ユーザ定義4(グラム陽性桿菌（GPR）)"
 * code.text = "グラム陽性桿菌（GPR）"
@@ -129,9 +129,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6B010000006174149 "培養同定(一般細菌)_喀痰_培養検査"
 * code.text = "培養同定(一般細菌)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -144,9 +144,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6B010000006174149 "培養同定(一般細菌)_喀痰_培養検査"
 * code.text = "培養同定(一般細菌)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -159,9 +159,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6B010000006174149 "培養同定(一般細菌)_喀痰_培養検査"
 * code.text = "培養同定(一般細菌)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -173,9 +173,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism-panels "Organism panels"
 * code.coding[jlac10] = $JP_ObservationLabResultCode_CS#6B010000006174149 "培養同定(一般細菌)_喀痰_培養検査"
 * code.text = "培養同定(一般細菌)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -188,9 +188,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism "Organism"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism "Organism"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#1303
 * code.text = "Staphylococcus aureus (MRSA)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -202,9 +202,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * subject = Reference(Patient/jp-patient-example-1)
 * status = #final
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-panels "Susceptibility panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-panels "Susceptibility panels"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#1303
 * code.text = "Staphylococcus aureus (MRSA)"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -222,9 +222,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism "Organism"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism "Organism"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#1131
 * code.text = "Streptococcus pneumoniae"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -236,9 +236,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-panels "Susceptibility panels"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-panels "Susceptibility panels"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#1131
 * code.text = "Streptococcus pneumoniae"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -258,9 +258,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism "Organism"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism "Organism"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#1101
 * code.text = "α-Streptococcus"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -272,9 +272,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * subject = Reference(Patient/jp-patient-example-1)
 * status = #final
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#organism "Organism"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#organism "Organism"
 * code.coding[infectious-agent] = $JP_Microbiology_InfectiousAgent_CS#6000
 * code.text = "Corynebacterium sp."
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
@@ -287,9 +287,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1821 "GM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -300,9 +300,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1871 "ABK"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -313,9 +313,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2121 "MINO"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -326,9 +326,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2006 "CLDM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -339,9 +339,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2516 "LVFX"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -352,9 +352,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2601 "FOM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -365,9 +365,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2301 "VCM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -378,9 +378,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1201 "PCG"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -391,9 +391,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2121 "MINO"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -405,9 +405,9 @@ Usage: #inline
 * subject = Reference(Patient/jp-patient-example-1)
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1901 "EM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -418,9 +418,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1656 "CTRX"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -431,9 +431,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1596 "CFPN-PI"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -444,9 +444,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2006 "CLDM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -457,9 +457,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2516 "LVFX"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -470,9 +470,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#1411 "MEPM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)
@@ -483,9 +483,9 @@ InstanceOf: JP_Observation_Microbiology
 Usage: #inline
 * status = #final
 * subject = Reference(Patient/jp-patient-example-1)
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
-* category[microbiology] = $Loinc_CS#18725-2 "Microbiology studies (set)"
-* category[microbiologyCategory] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory "Laboratory"
+* category[second] = $Loinc_CS#18725-2 "Microbiology studies (set)"
+* category[third] = $JP_MicrobiologyCategory_CS#susceptibility-measurements "Susceptibility measurements"
 * code.coding[antimicrobial-drug] = $JP_Microbiology_AntiMicrobialDrug_CS#2301 "VCM"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * performer = Reference(Practitioner/jp-practitioner-example-male-1)

--- a/input/fsh/examples/JP_DiagnosticReportRadiology_Example.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportRadiology_Example.fsh
@@ -9,8 +9,8 @@ Usage: #example
 * identifier.system = "http://jpfhir.jp/fhir/core/IdSystem/resourceInstance-identifier"
 * identifier.value = "123456"
 * status = #final
-* category[radiology] = $Loinc_CS#LP29684-5   "放射線"
-* category[radiology_sub] = $dicom-ontology#CT
+* category[first] = $Loinc_CS#LP29684-5   "放射線"
+* category[second] = $dicom-ontology#CT
 * code = $JP_DocumentCodes_CS#18748-4 "画像検査報告書"
 * subject = Reference(Patient/jp-patient-example-1)
 * effectiveDateTime = "2008-06-17"

--- a/input/fsh/examples/JP_Observation_BodyMeasurement_Example.fsh
+++ b/input/fsh/examples/JP_Observation_BodyMeasurement_Example.fsh
@@ -3,8 +3,8 @@ InstanceOf: JP_Observation_BodyMeasurement
 Title: "JP Core Observation BodyMeasurement Example 身体計測（体重）"
 Description: "身体計測（体重）"
 Usage: #example
-* category[bodyMeasurement] = $JP_SimpleObservationCategory_CS#body-measurement "Body Measurement"
-* category[bodyMeasurementCategory] = $JP_ObservationBodyMeasurementCategory_CS#weight "体重"
+* category[first] = $JP_SimpleObservationCategory_CS#body-measurement "Body Measurement"
+* category[second] = $JP_ObservationBodyMeasurementCategory_CS#weight "体重"
 * subject = Reference(Patient/jp-patient-example-1)
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#abc-local-456
 * code.coding[+] = $JP_ObservationBodyMeasurementCode_CS#31000296

--- a/input/fsh/examples/JP_Observation_Endoscopy_Diagnosis_Example_1.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Diagnosis_Example_1.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 診断（腺腫）"
 Description: "内視鏡診断（腺腫）"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_Endoscopy_Diagnosis_Example_2.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Diagnosis_Example_2.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 診断（[鋸歯状病変] HP）"
 Description: "内視鏡診断（[鋸歯状病変] HP）"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_1a.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_1a.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 所見（大きさ　長径４（�
 Description: "内視鏡所見（大きさ　長径４（ｍｍ））"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_1b.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_1b.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 所見（[大腸 肉眼型1] Is(p)
 Description: "内視鏡所見（[大腸 肉眼型1] Is(p)）"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_2a.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_2a.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 所見（大きさ　長径５（�
 Description: "内視鏡所見（大きさ　長径５（ｍｍ））"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_2b.fsh
+++ b/input/fsh/examples/JP_Observation_Endoscopy_Findings_Example_2b.fsh
@@ -4,8 +4,8 @@ Title: "JP Core Observation Endoscopy Example 所見（[大腸 肉眼型1] IIa�
 Description: "内視鏡所見（[大腸 肉眼型1] IIa）"
 Usage: #example
 * status = #final
-* category[0] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
-* category[1] = $Loinc_CS#LP7796-8 "内視鏡"
+* category[first] = $JP_SimpleObservationCategory_CS#procedure "Procedure"
+* category[second] = $Loinc_CS#LP7796-8 "内視鏡"
 * code
   * coding
     * system = $Loinc_CS

--- a/input/fsh/examples/JP_Observation_LabResult_Example.fsh
+++ b/input/fsh/examples/JP_Observation_LabResult_Example.fsh
@@ -4,7 +4,7 @@ Title: "JP Core Observation LabResult Example 検体検査（尿酸）"
 Description: "検体検査（尿酸）"
 Usage: #example
 * contained[0] = jp-servicerequest-example-1
-* category[laboratory] = $JP_SimpleObservationCategory_CS#laboratory
+* category[first] = $JP_SimpleObservationCategory_CS#laboratory
 * basedOn = Reference(ServiceRequest/jp-servicerequest-example-1)
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#05104 "尿酸"
 * code.coding[+] = $JP_ObservationLabResultCode_CS#3C020000002327101

--- a/input/fsh/examples/JP_Observation_PhysicalExam_Example.fsh
+++ b/input/fsh/examples/JP_Observation_PhysicalExam_Example.fsh
@@ -4,7 +4,7 @@ Title: "JP Core Observation PhysicalExam Example 身体所見（腹痛）"
 Description: "身体所見（腹痛）"
 Usage: #example
 * status = #final
-* category[physicalExam] = $JP_SimpleObservationCategory_CS#exam "Exam"
+* category[first] = $JP_SimpleObservationCategory_CS#exam "Exam"
 * code = $JP_PhysicalExamCode_CS#physical-findings "Physical Findings"
 * subject = Reference(Patient/jp-patient-example-1)
 * encounter = Reference(Encounter/jp-encounter-example-1)

--- a/input/fsh/examples/JP_Observation_SocialHistory_Example.fsh
+++ b/input/fsh/examples/JP_Observation_SocialHistory_Example.fsh
@@ -3,7 +3,7 @@ InstanceOf: JP_Observation_SocialHistory
 Title: "JP Core Observation SocialHistory Example 社会的背景（喫煙）"
 Description: "喫煙に関する項目"
 Usage: #example
-* category[socialHistory] = $JP_SimpleObservationCategory_CS#social-history "Social History"
+* category[first] = $JP_SimpleObservationCategory_CS#social-history "Social History"
 * subject = Reference(Patient/jp-patient-example-1)
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#abc-local-456 "ブリンクマン指数"
 * code.coding[+] = $JP_ObservationSocialHistoryCode_CS#MD0012920 "喫煙指数"

--- a/input/fsh/examples/JP_Observation_VitalSigns_Example.fsh
+++ b/input/fsh/examples/JP_Observation_VitalSigns_Example.fsh
@@ -3,8 +3,8 @@ InstanceOf: JP_Observation_VitalSigns
 Title: "JP Core Observation VitalSigns Example バイタル（呼吸数）"
 Description: "バイタル（呼吸数）"
 Usage: #example
-* category[vitalSigns] = $JP_SimpleObservationCategory_CS#vital-signs "Vital Signs"
-* category[vitalSignCategory] = $JP_ObservationVitalSignsCategory_CS#respiratory-function  "呼吸機能"
+* category[first] = $JP_SimpleObservationCategory_CS#vital-signs "Vital Signs"
+* category[second] = $JP_ObservationVitalSignsCategory_CS#respiratory-function  "呼吸機能"
 * subject = Reference(Patient/jp-patient-example-1)
 * code.coding[0] = http://abc-hospital.local/fhir/Observation/localcode#abc-local-456 "呼吸数"
 * code.coding[+] = $JP_ObservationVitalSignsCode_CS#31001369 "呼吸数"

--- a/input/fsh/profiles/JP_DiagnosticReport_DentalOral.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_DentalOral.fsh
@@ -20,13 +20,13 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 * category ^slicing.discriminator.type = #value
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
-* category contains dentaloral 1..1
+* category contains first 1..1
 * insert SetDefinition(category, サービスカテゴリー SS-MIX2拡張ストレージ構成の説明と構築ガイドラインに従う)
-* category[dentaloral] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP31759-1（歯科口腔）を使用する。"
-* category[dentaloral] from $JP_DiagnosticReportCategory_VS (required)
-* category[dentaloral].coding.system = $Loinc_CS (exactly)
-* category[dentaloral].coding.code 1..
-* category[dentaloral].coding.code = $Loinc_CS#LP31759-1 (exactly)
+* category[first] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP31759-1（歯科口腔）を使用する。"
+* category[first] from $JP_DiagnosticReportCategory_VS (required)
+* category[first].coding.system = $Loinc_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $Loinc_CS#LP31759-1 (exactly)
 
 * code.coding ^slicing.discriminator.type = #value
 * code.coding ^slicing.discriminator.path = "coding.system"

--- a/input/fsh/profiles/JP_DiagnosticReport_Endoscopy.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_Endoscopy.fsh
@@ -30,17 +30,17 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
 * category ^slicing.ordered = false
-* category contains endoscopy 1..1
+* category contains first 1..1
 * category ^short = "診断レポートの分野を表すコード。"
 * category ^definition = "診断レポートの分野を表すコード。"
-* category[endoscopy] ^short = "診断レポートの分野を表すコード。【詳細参照】"
-* category[endoscopy] ^definition = "診断レポートの分野を表すコード。"
-* category[endoscopy] ^comment = "JP_DiagnosticReportCategory_VSの中から「LP7796-8」（Endoscopy（内視鏡））を指定する。"
-* category[endoscopy] from $JP_DiagnosticReportCategory_VS (required)
-//* category[endoscopy] = $Loinc_CS#LP7796-8 "内視鏡" (exactly)
-* category[endoscopy].coding.system = $Loinc_CS (exactly)
-* category[endoscopy].coding.code 1..
-* category[endoscopy].coding.code = $Loinc_CS#LP7796-8 (exactly)
+* category[first] ^short = "診断レポートの分野を表すコード。【詳細参照】"
+* category[first] ^definition = "診断レポートの分野を表すコード。"
+* category[first] ^comment = "JP_DiagnosticReportCategory_VSの中から「LP7796-8」（Endoscopy（内視鏡））を指定する。"
+* category[first] from $JP_DiagnosticReportCategory_VS (required)
+//* category[first] = $Loinc_CS#LP7796-8 "内視鏡" (exactly)
+* category[first].coding.system = $Loinc_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $Loinc_CS#LP7796-8 (exactly)
 * code from $JP_DocumentCodes_Endoscopy_VS (extensible)
 * code ^short = "内視鏡分野の診断レポートを分類するためのコード。【詳細参照】"
 * code ^definition = "内視鏡分野の診断レポートを分類するためのコード。"

--- a/input/fsh/profiles/JP_DiagnosticReport_LabResult.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_LabResult.fsh
@@ -31,13 +31,13 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 // #patternでなく#valueでよいはずだが、#valueだと警告"For the complex type CodeableConcept, consider using a pattern rather than a fixed value to avoid over-constraining the instance"が出る。
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
-* category contains laboratory 1..1
+* category contains first 1..1
 * insert SetDefinition(category, 診断レポートを作成した臨床分野、部門、または診断サービスを分類するコード。検体査では、LoincコードのLP29693-6 検体検査/LAB を使用する。)
-* category[laboratory] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP29693-6(検体検査/LAB)を使用する。"
-* category[laboratory] from $JP_DiagnosticReportCategory_VS (required)
-* category[laboratory].coding.system = $Loinc_CS (exactly)
-* category[laboratory].coding.code 1..
-* category[laboratory].coding.code = $Loinc_CS#LP29693-6 (exactly)
+* category[first] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP29693-6(検体検査/LAB)を使用する。"
+* category[first] from $JP_DiagnosticReportCategory_VS (required)
+* category[first].coding.system = $Loinc_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $Loinc_CS#LP29693-6 (exactly)
 * code.coding ^slicing.discriminator.type = #value
 * code.coding ^slicing.discriminator.path = "system"
 * code.coding ^slicing.rules = #open

--- a/input/fsh/profiles/JP_DiagnosticReport_Microbiology.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_Microbiology.fsh
@@ -24,14 +24,14 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 // #patternでなく#valueでよいはずだが、#valueだと警告"For the complex type CodeableConcept, consider using a pattern rather than a fixed value to avoid over-constraining the instance"が出る。
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
-* category contains microbiology 1..1
+* category contains first 1..1
 * insert SetDefinition(category, 診断レポートを作成した臨床分野、部門、または診断サービスを分類するコード。微生物検査では、LoincコードのLP7819-8 微生物検査/MICRO を使用する。)
-* category[microbiology] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP7819-8 (微生物検査/MICRO)を使用する。"
-* category[microbiology] from $JP_DiagnosticReportCategory_VS (required)
-//* category[microbiology] = $Loinc_CS#LP7819-8  "微生物検査" (exactly)
-* category[microbiology].coding.system = $Loinc_CS (exactly)
-* category[microbiology].coding.code 1..
-* category[microbiology].coding.code = $Loinc_CS#LP7819-8 (exactly)
+* category[first] ^comment = "【JP Core仕様】レポートカテゴリーとして、LoincコードのLP7819-8 (微生物検査/MICRO)を使用する。"
+* category[first] from $JP_DiagnosticReportCategory_VS (required)
+//* category[first] = $Loinc_CS#LP7819-8  "微生物検査" (exactly)
+* category[first].coding.system = $Loinc_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $Loinc_CS#LP7819-8 (exactly)
 
 * code = $JP_DocumentCodes_CS#18725-2 "微生物学的検査報告書"
 * insert SetDefinition(code, 診断レポート種別「微生物学的検査報告書」を表す文書コード)

--- a/input/fsh/profiles/JP_DiagnosticReport_Radiology.fsh
+++ b/input/fsh/profiles/JP_DiagnosticReport_Radiology.fsh
@@ -43,24 +43,24 @@ Description: "このプロファイルはDiagnosticReportリソースに対し�
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
 * category ^slicing.ordered = false
-* category contains radiology 1..1 and radiology_sub ..*
+* category contains first 1..1 and second ..*
 
-* category[radiology] ^short = "レポートを作成した分野を分類するコード【詳細参照】"
-* category[radiology] ^definition = "レポートを作成した臨床分野・部門、または診断サービス（CT, US, MRIなど）を分類するコード。 これは、検索、並べ替え、および表示の目的で使用される。【JP-Core仕様】放射線レポートは第1コードとして LP29684-5 を固定値として設定。第2コード以下にDICOMModalityコードを列挙することでレポートの対象検査内容を示す。"
-* category[radiology] from $JP_DiagnosticReportCategory_VS (required)
-//* category[radiology] = $Loinc_CS#LP29684-5  "放射線" (exactly)
-* category[radiology].coding.system = $Loinc_CS (exactly)
-* category[radiology].coding.code 1..
-* category[radiology].coding.code = $Loinc_CS#LP29684-5 (exactly)
+* category[first] ^short = "レポートを作成した分野を分類するコード【詳細参照】"
+* category[first] ^definition = "レポートを作成した臨床分野・部門、または診断サービス（CT, US, MRIなど）を分類するコード。 これは、検索、並べ替え、および表示の目的で使用される。【JP-Core仕様】放射線レポートは第1コードとして LP29684-5 を固定値として設定。第2コード以下にDICOMModalityコードを列挙することでレポートの対象検査内容を示す。"
+* category[first] from $JP_DiagnosticReportCategory_VS (required)
+//* category[first] = $Loinc_CS#LP29684-5  "放射線" (exactly)
+* category[first].coding.system = $Loinc_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $Loinc_CS#LP29684-5 (exactly)
 
-* category[radiology_sub] ^short = "レポート対象のモダリティを示すコード【詳細参照】"
-* category[radiology_sub] ^definition = "レポート対象のモダリティを示すコード。放射線を表す第1コードのLP29684-5に続くサブカテゴリコードとして第2コード以下に保持される。複数のモダリティの組み合わせを許容するため、コードの列挙を許容する。"
-* category[radiology_sub] from $JP_DICOMModality_VS (required)
-* category[radiology_sub].coding.system = $dicom-ontology (exactly)
-* category[radiology_sub].coding.code ^short = "DICOMのモダリティコードを指定"
-* category[radiology_sub].coding.code ^definition = "DICOMのモダリティコードを指定"
-* category[radiology_sub].coding.display ^short = "DICOMのモダリティコードの意味を記載（例: 超音波検査）"
-* category[radiology_sub].coding.display ^definition = "DICOMのモダリティコードの意味を記載（例: 超音波検査）"
+* category[second] ^short = "レポート対象のモダリティを示すコード【詳細参照】"
+* category[second] ^definition = "レポート対象のモダリティを示すコード。放射線を表す第1コードのLP29684-5に続くサブカテゴリコードとして第2コード以下に保持される。複数のモダリティの組み合わせを許容するため、コードの列挙を許容する。"
+* category[second] from $JP_DICOMModality_VS (required)
+* category[second].coding.system = $dicom-ontology (exactly)
+* category[second].coding.code ^short = "DICOMのモダリティコードを指定"
+* category[second].coding.code ^definition = "DICOMのモダリティコードを指定"
+* category[second].coding.display ^short = "DICOMのモダリティコードの意味を記載（例: 超音波検査）"
+* category[second].coding.display ^definition = "DICOMのモダリティコードの意味を記載（例: 超音波検査）"
 
 * code ^definition = "この診断レポートを表現するコードや名称"
 * code ^comment = "【JP Core仕様】[画像診断レポート交換手順ガイドライン](https://www.jira-net.or.jp/publishing/files/jesra/JESRA_TR-0042_2018.pdf)「5.1 レポート種別コード」に記載されているLOINCコード [Diagnostic imaging study](https://loinc.org/18748-4/) を指定。コードを指定できない場合はCodeableConceptを使用せずテキスト等を直接コーディングすることも許容されるが、要素間の調整と事前・事後の内容の整合性確保のために独自の構造を提供する必要があるので留意すること。"

--- a/input/fsh/profiles/JP_Observation_BodyMeasurement.fsh
+++ b/input/fsh/profiles/JP_Observation_BodyMeasurement.fsh
@@ -17,15 +17,15 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator.path = "coding.system"
 * category ^slicing.rules = #open
 * category contains
-    bodyMeasurement 1..1 and
-    bodyMeasurementCategory 0..*
-* category[bodyMeasurement] from $JP_SimpleObservationCategory_VS (required)
-* category[bodyMeasurement].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[bodyMeasurement].coding.code 1..
-* category[bodyMeasurement].coding.code = #body-measurement (exactly)
-* category[bodyMeasurementCategory] from JP_ObservationBodyMeasurementCategory_VS (preferred)
-* category[bodyMeasurementCategory].coding.system = $JP_ObservationBodyMeasurementCategory_CS
-* category[bodyMeasurementCategory] ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類2．身体計測の「焦点」"
+    first 1..1 and
+    second 0..*
+* category[first] from $JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = #body-measurement (exactly)
+* category[second] from JP_ObservationBodyMeasurementCategory_VS (preferred)
+* category[second].coding.system = $JP_ObservationBodyMeasurementCategory_CS
+* category[second] ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類2．身体計測の「焦点」"
 * code from JP_ObservationBodyMeasurementCode_VS (preferred)
 * code ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類2．身体計測の「観察名称」"
 * subject 1..

--- a/input/fsh/profiles/JP_Observation_Endoscopy.fsh
+++ b/input/fsh/profiles/JP_Observation_Endoscopy.fsh
@@ -27,20 +27,20 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator.path = "coding.system"
 * category ^slicing.rules = #open
 * category contains
-    endoscopy 1..1 and
-    endoscopy_sub 1..1
+    first 1..1 and
+    second 1..1
 * category ^short = "このObservationを分類するコード【詳細参照】"
 * category ^comment = "内視鏡検査の第1カテゴリはJP_SimpleObservationCategory_VSからprocedureを指定、第2カテゴリはLOINCのPartコードLP7796-8（内視鏡）固定とする。"
-* category[endoscopy] ^short = "内視鏡検査の第1カテゴリはJP_SimpleObservationCategory_VSからprocedureを指定する。"
-* category[endoscopy] from JP_SimpleObservationCategory_VS (required)
-* category[endoscopy].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[endoscopy].coding.code 1..
-* category[endoscopy].coding.code = $JP_SimpleObservationCategory_CS#procedure (exactly)
-* category[endoscopy_sub] ^short = "第2カテゴリはLOINCのPartコードLP7796-8（内視鏡）固定とする。"
-* category[endoscopy_sub] from $JP_ObservationCategory_Endoscopy_VS (required)
-* category[endoscopy_sub].coding.system = $Loinc_CS (exactly)
-* category[endoscopy_sub].coding.code 1..
-* category[endoscopy_sub].coding.code = $Loinc_CS#LP7796-8 (exactly)
+* category[first] ^short = "内視鏡検査の第1カテゴリはJP_SimpleObservationCategory_VSからprocedureを指定する。"
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#procedure (exactly)
+* category[second] ^short = "第2カテゴリはLOINCのPartコードLP7796-8（内視鏡）固定とする。"
+* category[second] from $JP_ObservationCategory_Endoscopy_VS (required)
+* category[second].coding.system = $Loinc_CS (exactly)
+* category[second].coding.code 1..
+* category[second].coding.code = $Loinc_CS#LP7796-8 (exactly)
 * code from JP_ObservationEndoscopyCode_VS (preferred)
 * code ^short = "このObservationの対象を特定するコード。【詳細参照】"
 * code ^definition = "このObservationの対象を特定するコード。"

--- a/input/fsh/profiles/JP_Observation_LabResult.fsh
+++ b/input/fsh/profiles/JP_Observation_LabResult.fsh
@@ -41,23 +41,23 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator.type = #value
 * category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
-* category contains laboratory 1..1
+* category contains first 1..1
 * insert SetDefinition(category.coding, コード化されたカテゴリー)
 
-* category[laboratory] ^comment = "【JP Core仕様】推奨コード表「JP Core Simple Observation Category CodeSystem」より、このプロファイルでは「laboratory」固定とする。  
+* category[first] ^comment = "【JP Core仕様】推奨コード表「JP Core Simple Observation Category CodeSystem」より、このプロファイルでは「furst」固定とする。  
 (social-history | vital-signs | imaging | laboratory | procedure | survey | exam | therapy | activity)"
-* category[laboratory].coding ^comment = "【JP Core仕様】推奨コード表「JP Core Simple Observation Category CodeSystem」より、このプロファイルでは「laboratory」固定とする。"
+* category[first].coding ^comment = "【JP Core仕様】推奨コード表「JP Core Simple Observation Category CodeSystem」より、このプロファイルでは「laboratory」固定とする。"
 
-* insert SetDefinition(category[laboratory], 検体検査では、http://jpfhir.jp/fhir/core/CodeSystem/JP_SimpleObservationCategory_CS のコード表から\"laboratory\"を設定する。)
-* insert SetDefinition(category[laboratory].coding.system, 検体検査では、http://jpfhir.jp/fhir/core/CodeSystem/JP_SimpleObservationCategory_CS のコード表を使用する。)
-* insert SetDefinition(category[laboratory].coding.code, 検体検査を表すコード laboratory を設定する。)
+* insert SetDefinition(category[first], 検体検査では、http://jpfhir.jp/fhir/core/CodeSystem/JP_SimpleObservationCategory_CS のコード表から\"laboratory\"を設定する。)
+* insert SetDefinition(category[first].coding.system, 検体検査では、http://jpfhir.jp/fhir/core/CodeSystem/JP_SimpleObservationCategory_CS のコード表を使用する。)
+* insert SetDefinition(category[first].coding.code, 検体検査を表すコード laboratory を設定する。)
 
-* category[laboratory] from JP_SimpleObservationCategory_VS (required)
-* category[laboratory].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[laboratory].coding 1..1
-* category[laboratory].coding.code = $JP_SimpleObservationCategory_CS#laboratory (exactly)
-* category[laboratory].coding.system 1..1
-* category[laboratory].coding.code 1..1
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding 1..1
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#laboratory (exactly)
+* category[first].coding.system 1..1
+* category[first].coding.code 1..1
 
 * code from $JP_ObservationLabResultCode_VS (preferred)
 * code ^definition = "検査の内容の説明。検査名称。"

--- a/input/fsh/profiles/JP_Observation_Microbiology.fsh
+++ b/input/fsh/profiles/JP_Observation_Microbiology.fsh
@@ -1,7 +1,7 @@
 Profile: JP_Observation_Microbiology
 Parent: JP_Observation_Common
 Id: jp-observation-microbiology
-Title: "JP Core Observation Microbiology Profile"
+Title: "JP Core Observationsecond Profile"
 Description: "このプロファイルはObservationリソースに対して、微生物学検査のデータを送受信するための制約と拡張を定めたものである。"
 * ^url = "http://jpfhir.jp/fhir/core/StructureDefinition/JP_Observation_Microbiology"
 * ^status = #active
@@ -17,27 +17,27 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator.path = "coding.system"
 * category ^slicing.rules = #open
 * category contains
-    laboratory 1..1 and
-    microbiology 1..1 and
-    microbiologyCategory ..1
+    first 1..1 and
+    second 1..1 and
+    third ..1
 * category ^comment = "【JP Core仕様】日本では適切なコード体系が存在しないため、独自のバリューセットを定義する  
 JP CoreとしてはsimpleObservationコード体系を必須とし、他のローカルコード等を使用する場合はCategory要素の2つ目以降に設定する"
-* insert SetDefinition(category[laboratory], このObservationに関する分類（JP_SimpleObservationCategory_VS）、必須項目)
-* category[laboratory] from JP_SimpleObservationCategory_VS (required)
-* category[laboratory].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[laboratory].coding.code 1..
-* category[laboratory].coding.code = $JP_SimpleObservationCategory_CS#laboratory (exactly)
+* insert SetDefinition(category[first], このObservationに関する分類（JP_SimpleObservationCategory_VS）、必須項目)
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#laboratory (exactly)
 
-* insert SetDefinition(category[microbiology], このObservationに関するLOINC上の分類、任意項目)
-* category[microbiology] from $JP_ObservationCategory_Microbiology_VS (preferred)
-* category[microbiology].coding.system = $Loinc_CS (exactly)
-* category[microbiology].coding.code 1..
-* category[microbiology].coding.code = $Loinc_CS#18725-2 (exactly)
-* category[microbiology].coding.display = "Microbiology studies (set)"
+* insert SetDefinition(category[second], このObservationに関するLOINC上の分類、任意項目)
+* category[second] from $JP_ObservationCategory_Microbiology_VS (preferred)
+* category[second].coding.system = $Loinc_CS (exactly)
+* category[second].coding.code 1..
+* category[second].coding.code = $Loinc_CS#18725-2 (exactly)
+* category[second].coding.display = "Microbiology studies (set)"
 
-* insert SetDefinition(category[microbiologyCategory], このObservationに関する詳細分類、JP_MicrobiologyCategory_VSより選択する、任意項目)
-* category[microbiologyCategory] from $JP_MicrobiologyCategory_VS (required)
-* category[microbiologyCategory].coding.system = $JP_MicrobiologyCategory_CS (exactly)
+* insert SetDefinition(category[third], このObservationに関する詳細分類、JP_MicrobiologyCategory_VSより選択する、任意項目)
+* category[third] from $JP_MicrobiologyCategory_VS (required)
+* category[third].coding.system = $JP_MicrobiologyCategory_CS (exactly)
 
 * code 1..
 * code.coding ^slicing.discriminator.type = #value

--- a/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
+++ b/input/fsh/profiles/JP_Observation_PhysicalExam.fsh
@@ -16,11 +16,11 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator[+].type = #value
 * category ^slicing.discriminator[=].path = "$this"
 * category ^slicing.rules = #open
-* category contains physicalExam 1..1
-* category[physicalExam] from JP_SimpleObservationCategory_VS (required)
-* category[physicalExam].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[physicalExam].coding.code 1..
-* category[physicalExam].coding.code = $JP_SimpleObservationCategory_CS#exam (exactly)
+* category contains first 1..1
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#exam (exactly)
 * category ^comment = "【JP Core仕様】基底仕様のカテゴリ「exam」固定とする"
 * code ^comment = "【JP Core仕様】所見の有無を表すコード（固定値）"
 * code from JP_PhysicalExamCode_VS (preferred)

--- a/input/fsh/profiles/JP_Observation_SocialHistory.fsh
+++ b/input/fsh/profiles/JP_Observation_SocialHistory.fsh
@@ -16,11 +16,11 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator[+].type = #value
 * category ^slicing.discriminator[=].path = "$this"
 * category ^slicing.rules = #open
-* category contains socialHistory 1..1
-* category[socialHistory] from JP_SimpleObservationCategory_VS (required)
-* category[socialHistory].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[socialHistory].coding.code 1..
-* category[socialHistory].coding.code = $JP_SimpleObservationCategory_CS#social-history (exactly)
+* category contains first 1..1
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#social-history (exactly)
 * category ^comment = "【JP Core仕様】基底仕様のカテゴリ「social-history」固定とする"
 * code from JP_ObservationSocialHistoryCode_VS (preferred)
 * code ^comment = "MEDISのJ-MIXの「生活背景情報」（※宗教を除く）"

--- a/input/fsh/profiles/JP_Observation_VitalSigns.fsh
+++ b/input/fsh/profiles/JP_Observation_VitalSigns.fsh
@@ -17,15 +17,15 @@ Description: "このプロファイルはObservationリソースに対して、�
 * category ^slicing.discriminator[=].path = "coding.system"
 * category ^slicing.rules = #open
 * category contains
-    vitalSigns 1..1 and
-    vitalSignCategory 0..*
-* category[vitalSigns] from JP_SimpleObservationCategory_VS (required)
-* category[vitalSigns].coding.system = $JP_SimpleObservationCategory_CS (exactly)
-* category[vitalSigns].coding.code 1..
-* category[vitalSigns].coding.code = $JP_SimpleObservationCategory_CS#vital-signs (exactly)
-* category[vitalSignCategory] from JP_ObservationVitalSignsCategory_VS (preferred)
-* category[vitalSignCategory].coding.system = $JP_ObservationVitalSignsCategory_CS (exactly)
-* category[vitalSignCategory] ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類１．バイタルサインの「焦点」"
+    first 1..1 and
+    second 0..*
+* category[first] from JP_SimpleObservationCategory_VS (required)
+* category[first].coding.system = $JP_SimpleObservationCategory_CS (exactly)
+* category[first].coding.code 1..
+* category[first].coding.code = $JP_SimpleObservationCategory_CS#vital-signs (exactly)
+* category[second] from JP_ObservationVitalSignsCategory_VS (preferred)
+* category[second].coding.system = $JP_ObservationVitalSignsCategory_CS (exactly)
+* category[second] ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類１．バイタルサインの「焦点」"
 * code from JP_ObservationVitalSignsCode_VS (preferred)
 * code ^comment = "MEDISの看護実践用語標準マスター＜看護観察編＞の大分類１．バイタルサイン・基本情報、中分類１．バイタルサインの「観察名称」"
 * subject 1..


### PR DESCRIPTION
## 修正内容

Observation, DiagnosticReports familyのcategoryについてのネーミングルールを下記のように統一した。
|階層|slice名|
| --- | --- |
| 1 | first |
| 2 | second |
| 3 | third |


## Merge依頼先
SWG2

## レビュー観点

特にエラーが出ていなければいいと思います。

## 関連ISSUE

fixed #671 

## 補足
