### PR TITLE
PatientIdに利用する医療機関OIDの表記方法を変更した

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-patient-notes.md
@@ -32,7 +32,7 @@ JP Patient リソースで使用される拡張は次の通りである。
 
 | コンフォーマンス | パラメータ    | 型     | 例                                                           |
 | ---------------- | ------------- | ------ | ------------------------------------------------------------ |
-| SHALL            | identifier    | token  | GET [base]/Patient?identifier=urn:oid:1.2.392.100495.20.3.51.医療機関OID番号10桁\|123456 |
+| SHALL            | identifier    | token  | GET [base]/Patient?identifier=urn:oid:1.2.392.100495.20.3.51.1+[医療機関コード10桁]\|123456 |
 | SHOULD            | name          | string | GET [base]/Patient?name=山田%20太郎                            |
 | SHOULD           | birthdate,name | date,string  | GET [base]/Patient?birthdate=eq2013-01-14&name=山田%20太郎  |
 | SHOULD           | birthdate,gender | date,token  | GET [base]/Patient?birthdate=eq2013-01-14&gender=male  |


### PR DESCRIPTION
## 修正内容
医療機関OID番号10桁
→
xxxxxxxx.1+医療機関コード10桁
に変更した。