### PR TITLE
fixed Immunization 接種を行わなかった理由の記述方法について #846 statusReasonに変更

### DIFF
--- a/input/intro-notes/StructureDefinition-jp-immunization-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-immunization-notes.md
@@ -243,10 +243,10 @@ Immunization.occurrenceString要素を使用した例：
 ```
 
 ### 接種を行わなかった理由の記述方法について
-ワクチン接種を行わなかった理由を記述したい場合は、Immunization.reasonCode要素にCodeableConcept型で記述する。適当な標準コードが整備されていないため、ローカルコードを定義するか、CodeableConcept.text要素にテキストとして記述する。
+ワクチン接種を行わなかった理由を記述したい場合は、Immunization.statusReason要素にCodeableConcept型で記述する。適当な標準コードが整備されていないため、ローカルコードを定義するか、CodeableConcept.text要素にテキストとして記述する。
 
 ```json
-"reasonCode": [
+"statusReason": [
   {
     "text": "37.5℃以上の発熱があったため。"
   }


### PR DESCRIPTION
## 修正内容

## Merge依頼先
SWG45

## レビュー観点
たしかにreasonStatusにしなかった理由を書くことになっていました。

## 関連ISSUE
fixed #846 

## 補足
