### PR TITLE
fix(#755): postalCodeの値を '1600023' から '160-0023' に修正

### DIFF
--- a/input/fsh/examples/JP_Patient_Example.fsh
+++ b/input/fsh/examples/JP_Patient_Example.fsh
@@ -23,7 +23,7 @@ Usage: #example
 * telecom.use = #home
 * gender = #male
 * birthDate = "1970-01-01"
-* address.postalCode = "1600023"
+* address.postalCode = "160-0023"
 * address.text = "東京都新宿区"
 * extension[0].url = $patient-religion
 * extension[=].valueCodeableConcept = http://terminology.hl7.org/CodeSystem/v3-ReligiousAffiliation#1046 "Shinto"


### PR DESCRIPTION
## 修正内容

`input/fsh/JP_Patient_Example.fsh` の以下の内容を修正した：

- #755（line26）：postalCode の記述 `"1600023"` を `"160-0023"` に修正。説明文の記載内容と整合性を持たせた。

## Merge依頼先
SWG3

## レビュー観点
- postalCode の記述形式として `"160-0023"` が適切かどうか
- 説明と例の整合性が確保されているか

## 関連ISSUE
fixed #755

## 補足
