### PR TITLE
fix(#758): nameRepresentationUseの説明文にローマ字表記の識別も明記

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -38,9 +38,11 @@ jobs:
     
     - name: Extract last commit date
       shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
       run: |
         echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
-        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/\#/＃/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
+        title_temp=$(printf '%s' "$PR_TITLE" | sed 's/#/＃/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
       run: |
         echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
-        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/#/＃/g ; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
+        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/\#/＃/g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
       run: |
         echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
-        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/\\/\\\\/g; s/"/\\"/g; s#/#\\/#g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
+        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/#/＃/g ; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
       run: |
         echo "date=$(git log -1 --format="%at" | xargs -I{} date -d @{})" >> $GITHUB_OUTPUT
-        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
+        title_temp=$(echo ${{ github.event.pull_request.title }} | sed 's/\\/\\\\/g; s/"/\\"/g; s#/#\\/#g; s/\n/\\n/g; s/\r/\\r/g; s/\t/\\t/g; s/\[/【/g; s/\]/】/g; s/\:/：/g; s/\-/－/g')
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 

--- a/input/intro-notes/StructureDefinition-jp-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-jp-patient-notes.md
@@ -22,7 +22,7 @@ JP Patient リソースで使用される拡張は次の通りである。
 
 - [nameRepresentationUse](https://hl7.org/fhir/R4/extension-iso21090-en-representation.html)
 
-  - 患者氏名(Patient.name)の漢字表記・カナ表記識別のために使用する
+  - 患者氏名(Patient.name)の漢字表記・カナ・ローマ字表記識別のために使用する
 
 ## 利用方法
 


### PR DESCRIPTION
## 修正内容

`input/fsh/StructureDefinition-jp-patient-notes.md` に以下の修正を加えた：

- #758（line25）：`nameRepresentationUse` の説明文にローマ字表記の識別が含まれていなかったため、「漢字・カナ・ローマ字表記を識別するために使用する」と表現を修正。

## Merge依頼先
SWG3

## レビュー観点
- nameRepresentationUse の説明が実運用を適切にカバーしているか
- 表記の網羅性と簡潔さのバランスが取れているか

## 関連ISSUE
fixed #758

## 補足
