### PR TITLE
Condition Diagnosis Example　の病名が不整合

### DIFF
--- a/input/fsh/examples/JP_Condition_Diagnosis_Example.fsh
+++ b/input/fsh/examples/JP_Condition_Diagnosis_Example.fsh
@@ -1,28 +1,28 @@
 Instance:  jp-condition-diagnosis-example-1
 InstanceOf: JP_Condition_Diagnosis
-Title: "JP Core Condition Diagnosis Example 病名（過敏性大腸炎の初期疾患）"
-Description: "過敏性大腸炎の初期疾患の例"
+Title: "JP Core Condition Diagnosis Example 病名（右橈骨遠位端骨折の術後）"
+Description: "右橈骨遠位端骨折の術後の例"
 Usage: #example
 * extension[0]
   * url = $JP_Condition_DiseaseOutcome
   * valueCodeableConcept
     * coding[0]
       * system = "http://terminology.sample.com/CodeSystem/disease-outcome"
-      * code = #2
-      * display = "寛解"
+      * code = #1
+      * display = "中止"
     * coding[1]
       * system = $JP_ConditionDiseaseOutcomeJHSD0006_CS
-      * code = #M
-      * display = "寛解"
-    * text = "寛解"
+      * code = #I
+      * display = "中止"
+    * text = "中止(転医)"
 *  identifier
   * system = "http://terminology.sample.com/IdSystem/disease/1311234567"
   * value = "123456789012345"
 *  clinicalStatus
   * coding[0]
     * system = "http://terminology.hl7.org/CodeSystem/condition-clinical"
-    * code = #remission
-    * display = "Remission"
+    * code = #inactive
+    * display = "Inactive"
 *  verificationStatus
   *  coding[0]
     *  system = "http://terminology.hl7.org/CodeSystem/condition-ver-status"


### PR DESCRIPTION

## 修正内容
臨床的に内容がずれていたので右頭骨遠位端骨折の術後の例に併せて内容を修正した。


## Merge依頼先
SWG45

## レビュー観点
臨床的に合っているかどうか。


## 関連ISSUE

ref #910


## 補足

JHSD表0006を参照することになっているが、転帰区分がレセプト転帰区分とも合わないし、臨床的にも足りないように思います。

JHSD表 0006 －Outcome 転帰区分
（コーディングシステム名：JHSD0006）
Value Description
I 中止
M 寛解
C 継続
O その他

レセプト転帰区分
別表18 転帰区分コード
１ 治ゆ、死亡、中止以外
２ 治 ゆ
３ 死 亡
４ 中 止（転医）

JP CLINS退院サマリー
この状態の結果（転帰）。
Coding 記述はせず、text にのみ記述す
る。