### PR TITLE
fix(#908):組織名の不整合を修正

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -76,7 +76,7 @@ jobs:
       uses: Legion2/download-release-action@v2.1.0
       with:
         repository: HL7/fhir-ig-publisher
-        tag: 'latest'
+        tag: '2.0.25'
         path: .
         file: publisher.jar
     

--- a/input/fsh/examples/JP_Organization_Example.fsh
+++ b/input/fsh/examples/JP_Organization_Example.fsh
@@ -57,6 +57,6 @@ Title: "JP Core Organization Example ＡＢＣ検査株式会社"
 Description: "ＡＢＣ検査株式会社"
 Usage: #example
 * type = http://terminology.hl7.org/CodeSystem/organization-type#team "Organizational team"
-* name = "ひまわりＡＢＣ検査株式会社健康保険組合"
+* name = "ＡＢＣ検査株式会社"
 * identifier[+].system = "http://abc-hospital.local/fhir/Organization/localcode"
 * identifier[=].value = "000-000-000"


### PR DESCRIPTION
## 修正内容
[Organization Example　の組織名が不整合 #908](https://github.com/jami-fhir-jp-wg/jp-core-v1x/issues/908)
「JP Core Organization Example ＡＢＣ検査株式会社」に対して
「name: ひまわりＡＢＣ検査株式会社健康保険組合」は不整合であるため、
「name:ＡＢＣ検査株式会社」となるよう修正いたしました。
修正ファイル：input\fsh\examples\JP_Organization_Example.fsh

## Merge依頼先
SWG3

## レビュー観点
・OragenizationリソースのExampleにて組織名称が統一されているかどうか

## 関連ISSUE
fixed #908 

## 補足
