### PR TITLE
[High] feat: ConceptMap 4 件を新規追加 — 日本独自コード体系と国際標準のマッピング (closes #944)

### DIFF
--- a/input/fsh/aliases-jpcore.fsh
+++ b/input/fsh/aliases-jpcore.fsh
@@ -120,6 +120,12 @@ Alias: $JP_Patient_Race = http://jpfhir.jp/fhir/core/Extension/StructureDefiniti
 Alias: $JP_Client_CapabilityStatement = http://jpfhir.jp/fhir/core/CapabilityStatement/JP_Client_CapabilityStatement
 Alias: $JP_Server_CapabilityStatement = http://jpfhir.jp/fhir/core/CapabilityStatement/JP_Server_CapabilityStatement
 
+// ConceptMap
+Alias: $JP_BodyMeasurement_to_LOINC = http://jpfhir.jp/fhir/core/ConceptMap/JP_BodyMeasurement_to_LOINC
+Alias: $JP_ConditionDiseaseOutcomeHL70241_to_SNOMED = http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED
+Alias: $JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006 = http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006
+Alias: $JP_ConditionDiseaseOutcomeHL70241_to_Receipt = http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_Receipt
+
 // SearchParameter
 Alias: $JP_Coverage_InsuredPersonNumber_SP = http://jpfhir.jp/fhir/core/SearchParameter/JP_Coverage_InsuredPersonNumber_SP
 Alias: $JP_Coverage_InsuredPersonSubNumber_SP = http://jpfhir.jp/fhir/core/SearchParameter/JP_Coverage_InsuredPersonSubNumber_SP

--- a/input/fsh/conceptmaps/JP_BodyMeasurement_to_LOINC.fsh
+++ b/input/fsh/conceptmaps/JP_BodyMeasurement_to_LOINC.fsh
@@ -1,0 +1,118 @@
+// ==============================
+//   ConceptMap 定義
+// ==============================
+Instance: jp-bodymeasurement-to-loinc
+InstanceOf: ConceptMap
+Usage: #definition
+* url = "http://jpfhir.jp/fhir/core/ConceptMap/JP_BodyMeasurement_to_LOINC"
+* name = "JP_BodyMeasurement_to_LOINC"
+* title = "JP Core BodyMeasurement to LOINC ConceptMap"
+* status = #active
+* experimental = false
+* date = "2025-07-30"
+* description = "JP Core 身体計測コード（MEDIS 看護実践用語標準マスター由来）と LOINC との対応マッピング。\
+相互運用性向上のための参考マッピングであり、すべての項目を網羅しているわけではない。\
+マッピングの採用にあたっては各施設の臨床的判断が必要。"
+* copyright = "JP Core: Copyright MEDIS-DC 一般財団法人 医療情報システム開発センター / LOINC: This content LOINC® is copyright © 1995+ Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc."
+* sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ObservationBodyMeasurementCode_CS"
+* targetUri = "http://loinc.org"
+* group[0].source = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ObservationBodyMeasurementCode_CS"
+* group[=].target = "http://loinc.org"
+// --- 体重 ---
+* group[=].element[+].code = #31000296
+* group[=].element[=].display = "体重(Kg)"
+* group[=].element[=].target[+].code = #29463-7
+* group[=].element[=].target[=].display = "Body weight"
+* group[=].element[=].target[=].equivalence = #equivalent
+* group[=].element[+].code = #31000297
+* group[=].element[=].display = "体重(g)"
+* group[=].element[=].target[+].code = #29463-7
+* group[=].element[=].target[=].display = "Body weight"
+* group[=].element[=].target[=].equivalence = #equivalent
+* group[=].element[=].target[=].comment = "単位は g だが体重という概念は同一。LOINC 29463-7 で UCUM単位 g を指定して表現する。"
+// --- 身長 ---
+* group[=].element[+].code = #31000298
+* group[=].element[=].display = "身長"
+* group[=].element[=].target[+].code = #8302-2
+* group[=].element[=].target[=].display = "Body height"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 胸囲 ---
+* group[=].element[+].code = #31000299
+* group[=].element[=].display = "胸囲"
+* group[=].element[=].target[+].code = #9561-3
+* group[=].element[=].target[=].display = "Chest circumference at xiphoid process"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "LOINCの概念は胸骨剣状突起レベルを指定しているが、JP側はレベル未指定。"
+// --- 腹囲 ---
+* group[=].element[+].code = #31000300
+* group[=].element[=].display = "腹囲（臍上）"
+* group[=].element[=].target[+].code = #8280-0
+* group[=].element[=].target[=].display = "Waist Circumference at umbilicus [Length] by Tape measure"
+* group[=].element[=].target[=].equivalence = #equivalent
+* group[=].element[+].code = #31000301
+* group[=].element[=].display = "腹囲"
+* group[=].element[=].target[+].code = #56115-9
+* group[=].element[=].target[=].display = "Waist Circumference by Tape measure"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 体脂肪率 ---
+* group[=].element[+].code = #31001697
+* group[=].element[=].display = "体脂肪率"
+* group[=].element[=].target[+].code = #41982-0
+* group[=].element[=].target[=].display = "Percentage of body fat Measured"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 出生体重 ---
+* group[=].element[+].code = #31002900
+* group[=].element[=].display = "出生体重"
+* group[=].element[=].target[+].code = #8339-4
+* group[=].element[=].target[=].display = "Birth weight Measured"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- BMI ---
+* group[=].element[+].code = #31003020
+* group[=].element[=].display = "ＢＭＩ"
+* group[=].element[=].target[+].code = #39156-5
+* group[=].element[=].target[=].display = "Body mass index (BMI) [Ratio]"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 標準体重 ---
+* group[=].element[+].code = #31003138
+* group[=].element[=].display = "標準体重"
+* group[=].element[=].target[+].code = #59574-4
+* group[=].element[=].target[=].display = "Body weight special circumstances"
+* group[=].element[=].target[=].equivalence = #inexact
+* group[=].element[=].target[=].comment = "LOINCに標準体重（理想体重）の直接対応コードがないため暫定。"
+// --- 上腕周囲長（ＡＣ） ---
+* group[=].element[+].code = #31003421
+* group[=].element[=].display = "上腕周囲長（ＡＣ）"
+* group[=].element[=].target[+].code = #56072-2
+* group[=].element[=].target[=].display = "Arm circumference"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "LOINCは上腕の左右を区別しないため wider。"
+// --- 下腿周囲長（ＣＣ） ---
+* group[=].element[+].code = #31003422
+* group[=].element[=].display = "下腿周囲長（ＣＣ）"
+* group[=].element[=].target[+].code = #56162-1
+* group[=].element[=].target[=].display = "Calf circumference"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "LOINCは下腿の左右を区別しないため wider。"
+// --- 頭囲 ---
+* group[=].element[+].code = #31006116
+* group[=].element[=].display = "頭囲"
+* group[=].element[=].target[+].code = #9843-4
+* group[=].element[=].target[=].display = "Head Occipital-frontal circumference by Tape measure"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 握力 ---
+* group[=].element[+].code = #31006215
+* group[=].element[=].display = "握力（右）"
+* group[=].element[=].target[+].code = #62951-8
+* group[=].element[=].target[=].display = "Grip strength Hand - right Dynamometer"
+* group[=].element[=].target[=].equivalence = #equivalent
+* group[=].element[+].code = #31006216
+* group[=].element[=].display = "握力（左）"
+* group[=].element[=].target[+].code = #62952-6
+* group[=].element[=].target[=].display = "Grip strength Hand - left Dynamometer"
+* group[=].element[=].target[=].equivalence = #equivalent
+// --- 体重変化量 ---
+* group[=].element[+].code = #31003727
+* group[=].element[=].display = "体重変化量(Kg)"
+* group[=].element[=].target[+].code = #79300-3
+* group[=].element[=].target[=].display = "Weight change [Mass]"
+* group[=].element[=].target[=].equivalence = #equivalent

--- a/input/fsh/conceptmaps/JP_BodyMeasurement_to_LOINC.fsh
+++ b/input/fsh/conceptmaps/JP_BodyMeasurement_to_LOINC.fsh
@@ -10,9 +10,7 @@ Usage: #definition
 * status = #active
 * experimental = false
 * date = "2025-07-30"
-* description = "JP Core 身体計測コード（MEDIS 看護実践用語標準マスター由来）と LOINC との対応マッピング。\
-相互運用性向上のための参考マッピングであり、すべての項目を網羅しているわけではない。\
-マッピングの採用にあたっては各施設の臨床的判断が必要。"
+* description = "JP Core 身体計測コード（MEDIS 看護実践用語標準マスター由来）と LOINC との対応マッピング。相互運用性向上のための参考マッピングであり、すべての項目を網羅しているわけではない。マッピングの採用にあたっては各施設の臨床的判断が必要。"
 * copyright = "JP Core: Copyright MEDIS-DC 一般財団法人 医療情報システム開発センター / LOINC: This content LOINC® is copyright © 1995+ Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc."
 * sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ObservationBodyMeasurementCode_CS"
 * targetUri = "http://loinc.org"

--- a/input/fsh/conceptmaps/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED.fsh
+++ b/input/fsh/conceptmaps/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED.fsh
@@ -1,0 +1,64 @@
+// ==============================
+//   ConceptMap 定義
+// ==============================
+Instance: jp-condition-disease-outcome-hl70241-to-snomed
+InstanceOf: ConceptMap
+Usage: #definition
+* url = "http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED"
+* name = "JP_ConditionDiseaseOutcomeHL70241_to_SNOMED"
+* title = "JP Core Condition Disease Outcome HL7 Table 0241 to SNOMED CT ConceptMap"
+* status = #active
+* experimental = false
+* date = "2025-07-30"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードと SNOMED CT との対応マッピング。\
+国際的な相互運用性のための参考マッピングであり、SNOMED CT ライセンスの取得が必要。\
+マッピングの採用にあたっては最新の SNOMED CT リリースでの確認が必要。"
+* copyright = "JP Core: Copyright HL7 Japan / SNOMED CT: This material includes SNOMED Clinical Terms® (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists."
+* sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* targetUri = "http://snomed.info/sct"
+* group[0].source = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* group[=].target = "http://snomed.info/sct"
+// D: 死亡
+* group[=].element[+].code = #D
+* group[=].element[=].display = "死亡"
+* group[=].element[=].target[+].code = #419099009
+* group[=].element[=].target[=].display = "Dead (finding)"
+* group[=].element[=].target[=].equivalence = #equivalent
+// R: 回復
+* group[=].element[+].code = #R
+* group[=].element[=].display = "回復"
+* group[=].element[=].target[+].code = #371236003
+* group[=].element[=].target[=].display = "Patient's condition improved (finding)"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「回復」は改善全般を指し、完全回復（F）も含むため、SNOMED CT の「改善」にマップ。完全回復（F）との区別は本マッピングでは #R を wider として扱う。"
+// N: 回復せず／変わらない
+* group[=].element[+].code = #N
+* group[=].element[=].display = "回復せず／変わらない"
+* group[=].element[=].target[+].code = #271299001
+* group[=].element[=].target[=].display = "Patient's condition unchanged (finding)"
+* group[=].element[=].target[=].equivalence = #equivalent
+// W: 悪化
+* group[=].element[+].code = #W
+* group[=].element[=].display = "悪化"
+* group[=].element[=].target[+].code = #371240007
+* group[=].element[=].target[=].display = "Patient's condition worsened (finding)"
+* group[=].element[=].target[=].equivalence = #equivalent
+// S: 後遺症
+* group[=].element[+].code = #S
+* group[=].element[=].display = "後遺症"
+* group[=].element[=].target[+].code = #302898002
+* group[=].element[=].target[=].display = "Sequela (morphologic abnormality)"
+* group[=].element[=].target[=].equivalence = #inexact
+* group[=].element[=].target[=].comment = "SNOMED CT の Sequela は形態的異常として分類されており、HL70241 の意味と完全一致はしない。代替として 444784007 (Complication of illness) の使用も検討されたい。"
+// F: 完全に回復した
+* group[=].element[+].code = #F
+* group[=].element[=].display = "完全に回復した"
+* group[=].element[=].target[+].code = #370996005
+* group[=].element[=].target[=].display = "Patient's condition resolved (finding)"
+* group[=].element[=].target[=].equivalence = #equivalent
+// U: 未知
+* group[=].element[+].code = #U
+* group[=].element[=].display = "未知"
+* group[=].element[=].target[+].code = #261665006
+* group[=].element[=].target[=].display = "Unknown (qualifier value)"
+* group[=].element[=].target[=].equivalence = #equivalent

--- a/input/fsh/conceptmaps/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED.fsh
+++ b/input/fsh/conceptmaps/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED.fsh
@@ -10,9 +10,7 @@ Usage: #definition
 * status = #active
 * experimental = false
 * date = "2025-07-30"
-* description = "HL7 v2 Table 0241（Patient Outcome）コードと SNOMED CT との対応マッピング。\
-国際的な相互運用性のための参考マッピングであり、SNOMED CT ライセンスの取得が必要。\
-マッピングの採用にあたっては最新の SNOMED CT リリースでの確認が必要。"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードと SNOMED CT との対応マッピング。国際的な相互運用性のための参考マッピングであり、SNOMED CT ライセンスの取得が必要。マッピングの採用にあたっては最新の SNOMED CT リリースでの確認が必要。"
 * copyright = "JP Core: Copyright HL7 Japan / SNOMED CT: This material includes SNOMED Clinical Terms® (SNOMED CT®) which is used by permission of the International Health Terminology Standards Development Organisation (IHTSDO). All rights reserved. SNOMED CT®, was originally created by The College of American Pathologists."
 * sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
 * targetUri = "http://snomed.info/sct"

--- a/input/fsh/conceptmaps/JP_ConditionDiseaseOutcome_Mapping.fsh
+++ b/input/fsh/conceptmaps/JP_ConditionDiseaseOutcome_Mapping.fsh
@@ -10,9 +10,7 @@ Usage: #definition
 * status = #active
 * experimental = false
 * date = "2025-07-30"
-* description = "HL7 v2 Table 0241（Patient Outcome）コードと JAHIS JHSD表0006（転帰区分）との対応マッピング。\
-JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。\
-2 つの体系は概念的粒度が異なるため、一部のコードは wider または inexact となる。"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードと JAHIS JHSD表0006（転帰区分）との対応マッピング。JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。2 つの体系は概念的粒度が異なるため、一部のコードは wider または inexact となる。"
 * copyright = "JP Core: Copyright HL7 Japan (出典：HL7-0241) / JHSD0006: Copyright Japanese Association of Healthcare Information Systems Industry(JAHIS) 一般社団法人保健医療福祉情報システム工業会"
 * sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
 * targetUri = "http://jpfhir.jp/fhir/core/CodeSystem/JHSD0006"
@@ -79,8 +77,7 @@ Usage: #definition
 * status = #active
 * experimental = false
 * date = "2025-07-30"
-* description = "HL7 v2 Table 0241（Patient Outcome）コードとレセプト電算システム転帰区分との対応マッピング。\
-JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードとレセプト電算システム転帰区分との対応マッピング。JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。"
 * copyright = "JP Core: Copyright HL7 Japan (出典：HL7-0241) / レセプト電算: Copyright 社会保険診療報酬支払基金"
 * sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
 * targetUri = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ConditionDiseaseOutcomeReceipt_CS"

--- a/input/fsh/conceptmaps/JP_ConditionDiseaseOutcome_Mapping.fsh
+++ b/input/fsh/conceptmaps/JP_ConditionDiseaseOutcome_Mapping.fsh
@@ -1,0 +1,135 @@
+// ==============================
+//   ConceptMap 定義：病名転帰 3 系統間マッピング（HL70241 ↔ JHSD0006）
+// ==============================
+Instance: jp-condition-disease-outcome-hl70241-to-jhsd0006
+InstanceOf: ConceptMap
+Usage: #definition
+* url = "http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006"
+* name = "JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006"
+* title = "JP Core Condition Disease Outcome HL7 Table 0241 to JHSD0006 ConceptMap"
+* status = #active
+* experimental = false
+* date = "2025-07-30"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードと JAHIS JHSD表0006（転帰区分）との対応マッピング。\
+JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。\
+2 つの体系は概念的粒度が異なるため、一部のコードは wider または inexact となる。"
+* copyright = "JP Core: Copyright HL7 Japan (出典：HL7-0241) / JHSD0006: Copyright Japanese Association of Healthcare Information Systems Industry(JAHIS) 一般社団法人保健医療福祉情報システム工業会"
+* sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* targetUri = "http://jpfhir.jp/fhir/core/CodeSystem/JHSD0006"
+* group[0].source = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* group[=].target = "http://jpfhir.jp/fhir/core/CodeSystem/JHSD0006"
+// D: 死亡 → JHSD0006 に死亡コードなし
+* group[=].element[+].code = #D
+* group[=].element[=].display = "死亡"
+* group[=].element[=].target[+].code = #O
+* group[=].element[=].target[=].display = "その他"
+* group[=].element[=].target[=].equivalence = #inexact
+* group[=].element[=].target[=].comment = "JHSD0006 に死亡に直接対応するコードがないため「その他」にマップ。レセプト電算転帰の #3（死亡）との組み合わせ使用を推奨。"
+// R: 回復 → 寛解
+* group[=].element[+].code = #R
+* group[=].element[=].display = "回復"
+* group[=].element[=].target[+].code = #M
+* group[=].element[=].target[=].display = "寛解"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「寛解（M）」は症状の軽減・消失を示し、「回復（R）」の一側面に相当するが、完全回復（F）は寛解の上位概念ではないため wider。"
+// N: 回復せず／変わらない → 継続
+* group[=].element[+].code = #N
+* group[=].element[=].display = "回復せず／変わらない"
+* group[=].element[=].target[+].code = #C
+* group[=].element[=].target[=].display = "継続"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「継続（C）」は治療継続中を示し、変わらない状態に相当するが、悪化（W）も継続に包含されるため wider。"
+// W: 悪化 → 継続（JHSD0006 に悪化コードなし）
+* group[=].element[+].code = #W
+* group[=].element[=].display = "悪化"
+* group[=].element[=].target[+].code = #C
+* group[=].element[=].target[=].display = "継続"
+* group[=].element[=].target[=].equivalence = #inexact
+* group[=].element[=].target[=].comment = "JHSD0006 に悪化の直接対応コードがないため「継続」にマップ。情報が失われるため、悪化状態の記録にはレセプト電算転帰または SNOMED CT マッピングを推奨。"
+// S: 後遺症 → その他
+* group[=].element[+].code = #S
+* group[=].element[=].display = "後遺症"
+* group[=].element[=].target[+].code = #O
+* group[=].element[=].target[=].display = "その他"
+* group[=].element[=].target[=].equivalence = #inexact
+* group[=].element[=].target[=].comment = "JHSD0006 に後遺症の直接対応コードがない。"
+// F: 完全に回復した → 寛解
+* group[=].element[+].code = #F
+* group[=].element[=].display = "完全に回復した"
+* group[=].element[=].target[+].code = #M
+* group[=].element[=].target[=].display = "寛解"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「寛解（M）」は部分的寛解も含むため wider。完全回復であることをより精確に示すには SNOMED CT マッピング（370996005 Patient's condition resolved）も併用推奨。"
+// U: 未知 → その他
+* group[=].element[+].code = #U
+* group[=].element[=].display = "未知"
+* group[=].element[=].target[+].code = #O
+* group[=].element[=].target[=].display = "その他"
+* group[=].element[=].target[=].equivalence = #relatedto
+
+// ==============================
+//   ConceptMap 定義：病名転帰 3 系統間マッピング（HL70241 ↔ レセプト電算転帰）
+// ==============================
+Instance: jp-condition-disease-outcome-hl70241-to-receipt
+InstanceOf: ConceptMap
+Usage: #definition
+* url = "http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_Receipt"
+* name = "JP_ConditionDiseaseOutcomeHL70241_to_Receipt"
+* title = "JP Core Condition Disease Outcome HL7 Table 0241 to Receipt ConceptMap"
+* status = #active
+* experimental = false
+* date = "2025-07-30"
+* description = "HL7 v2 Table 0241（Patient Outcome）コードとレセプト電算システム転帰区分との対応マッピング。\
+JP Core JP_Condition_Diagnosis プロファイルにおいて、両コード体系で転帰を記録する際の変換の参考として使用する。"
+* copyright = "JP Core: Copyright HL7 Japan (出典：HL7-0241) / レセプト電算: Copyright 社会保険診療報酬支払基金"
+* sourceUri = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* targetUri = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ConditionDiseaseOutcomeReceipt_CS"
+* group[0].source = "http://jpfhir.jp/fhir/core/CodeSystem/HL70241"
+* group[=].target = "http://jpfhir.jp/fhir/core/CodeSystem/JP_ConditionDiseaseOutcomeReceipt_CS"
+// D: 死亡 → 3: 死亡
+* group[=].element[+].code = #D
+* group[=].element[=].display = "死亡"
+* group[=].element[=].target[+].code = #3
+* group[=].element[=].target[=].display = "死亡"
+* group[=].element[=].target[=].equivalence = #equivalent
+// R: 回復 → 2: 治ゆ
+* group[=].element[+].code = #R
+* group[=].element[=].display = "回復"
+* group[=].element[=].target[+].code = #2
+* group[=].element[=].target[=].display = "治ゆ"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「治ゆ」は完全回復を指すため、「回復（R）」より狭義。F（完全回復）のみが equivalent。"
+// N: 回復せず／変わらない → 1: 治ゆ・死亡・中止以外（継続）
+* group[=].element[+].code = #N
+* group[=].element[=].display = "回復せず／変わらない"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "治ゆ、死亡、中止以外"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "「1：治ゆ・死亡・中止以外」は継続中全般を示すため wider。悪化（W）や後遺症（S）も #1 に含まれる。"
+// W: 悪化 → 1: 治ゆ・死亡・中止以外（継続）
+* group[=].element[+].code = #W
+* group[=].element[=].display = "悪化"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "治ゆ、死亡、中止以外"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "レセプト電算に悪化の直接対応コードがないため「継続（#1）」にマップ。情報が失われる。"
+// S: 後遺症 → 1: 治ゆ・死亡・中止以外（継続）
+* group[=].element[+].code = #S
+* group[=].element[=].display = "後遺症"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "治ゆ、死亡、中止以外"
+* group[=].element[=].target[=].equivalence = #wider
+* group[=].element[=].target[=].comment = "レセプト電算に後遺症の直接対応コードがないため「継続（#1）」にマップ。"
+// F: 完全に回復した → 2: 治ゆ
+* group[=].element[+].code = #F
+* group[=].element[=].display = "完全に回復した"
+* group[=].element[=].target[+].code = #2
+* group[=].element[=].target[=].display = "治ゆ"
+* group[=].element[=].target[=].equivalence = #equivalent
+// U: 未知 → 1: 治ゆ・死亡・中止以外（デフォルト）
+* group[=].element[+].code = #U
+* group[=].element[=].display = "未知"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "治ゆ、死亡、中止以外"
+* group[=].element[=].target[=].equivalence = #relatedto
+* group[=].element[=].target[=].comment = "不明な転帰の暫定値。実際の転帰確認後に適切なコードに更新すること。"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -137,6 +137,10 @@ parameters:  # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+
   special-url:
     - http://jpfhir.jp/fhir/core/CapabilityStatement/JP_Client_CapabilityStatement
     - http://jpfhir.jp/fhir/core/CapabilityStatement/JP_Server_CapabilityStatement
+    - http://jpfhir.jp/fhir/core/ConceptMap/JP_BodyMeasurement_to_LOINC
+    - http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_SNOMED
+    - http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006
+    - http://jpfhir.jp/fhir/core/ConceptMap/JP_ConditionDiseaseOutcomeHL70241_to_Receipt
     - http://jpfhir.jp/fhir/core/CodeSystem/HL70241
     - http://jpfhir.jp/fhir/core/CodeSystem/JP_ConditionDiseaseOutcomeReceipt_CS
     - http://jpfhir.jp/fhir/core/CodeSystem/JP_DentalBodySite_CS


### PR DESCRIPTION
## Summary

Issue #944「ConceptMap が IG 全体で 0 件」を解消するため、日本独自コード体系と国際標準との相互運用性確保のための ConceptMap 4 件を新規追加。

## 追加した ConceptMap

### `JP_BodyMeasurement_to_LOINC`
- **対象**: JP Core 身体計測コード (MEDIS 看護実践用語標準マスター) → LOINC
- **件数**: 16 項目
- **主要マッピング**:

  | JP コード | JP 表示 | LOINC | LOINC 表示 | equivalence |
  |---|---|---|---|---|
  | 31000296 | 体重(Kg) | 29463-7 | Body weight | equivalent |
  | 31000298 | 身長 | 8302-2 | Body height | equivalent |
  | 31003020 | BMI | 39156-5 | Body mass index (BMI) [Ratio] | equivalent |
  | 31000300 | 腹囲（臍上） | 8280-0 | Waist Circumference at umbilicus | equivalent |
  | 31006116 | 頭囲 | 9843-4 | Head Occipital-frontal circumference | equivalent |
  | 31006215 | 握力（右） | 62951-8 | Grip strength Hand - right | equivalent |

### `JP_ConditionDiseaseOutcomeHL70241_to_SNOMED`
- **対象**: HL7 v2 Table 0241 (Patient Outcome) → SNOMED CT
- **件数**: 7 コード全件

  | HL70241 | 日本語 | SNOMED CT | 表示 | equivalence |
  |---|---|---|---|---|
  | D | 死亡 | 419099009 | Dead (finding) | equivalent |
  | F | 完全に回復した | 370996005 | Patient's condition resolved | equivalent |
  | R | 回復 | 371236003 | Patient's condition improved | wider |
  | N | 回復せず／変わらない | 271299001 | Patient's condition unchanged | equivalent |
  | W | 悪化 | 371240007 | Patient's condition worsened | equivalent |
  | U | 未知 | 261665006 | Unknown | equivalent |

### `JP_ConditionDiseaseOutcomeHL70241_to_JHSD0006`
- **対象**: HL70241 ↔ JAHIS JHSD表0006 (病名転帰 3 系統間マッピング)

### `JP_ConditionDiseaseOutcomeHL70241_to_Receipt`
- **対象**: HL70241 ↔ レセプト電算転帰区分 (病名転帰 3 系統間マッピング)

## 変更ファイル一覧

```
input/fsh/conceptmaps/                              (新規ディレクトリ)
  JP_BodyMeasurement_to_LOINC.fsh                  (新規)
  JP_ConditionDiseaseOutcomeHL70241_to_SNOMED.fsh  (新規)
  JP_ConditionDiseaseOutcome_Mapping.fsh           (新規: HL70241↔JHSD0006, HL70241↔レセプト)
input/fsh/aliases-jpcore.fsh                       (ConceptMap URL alias 4 件追加)
sushi-config.yaml                                  (special-url に 4 ConceptMap URL 追加)
```

## 注意事項

- **SNOMED CT マッピングについて**: SNOMED CT の利用にはライセンス取得が必要。各コードは最新の SNOMED CT リリースでの妥当性確認を推奨。
- **すべてのマッピング**: 参考マッピングであり、臨床的採用にあたっては医療専門家による確認が必要。
- **equivalence の使い方**: `equivalent` / `wider` / `inexact` / `relatedto` を適切に設定し、情報損失がある箇所は `comment` に注記済み。

## Test plan

- [ ] SUSHI コンパイル (`sushi .`) でエラーなく JSON 生成されること
- [ ] `fsh-generated/resources/` に `ConceptMap-jp-bodymeasurement-to-loinc.json` 等が生成されること
- [ ] IG Publisher のビルドで ConceptMap が artifacts に表示されること
- [ ] 各 ConceptMap の URL が `sushi-config.yaml` の `special-url` リストに含まれること

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)