### PR TITLE
fix: Observation の category/interpretation slicing discriminator を pattern+$this に修正 (#953)

### DIFF
--- a/input/fsh/profiles/JP_Observation_Common.fsh
+++ b/input/fsh/profiles/JP_Observation_Common.fsh
@@ -22,8 +22,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 * status ^comment = "このリソースは現在有効でないというマークをするコードを含んでいるため、この要素はモディファイアー（修飾的要素）として位置づけられている。"
 * insert SetDefinition(category, 行われた検査の一般的なタイプの分類。JP Core Observation Common Profileの【詳細説明】を参照のこと。)
 //* category from $JP_SimpleObservationCategory_VS (preferred)
-* category ^slicing.discriminator.type = #value
-* category ^slicing.discriminator.path = "coding.system"
+* category ^slicing.discriminator.type = #pattern
+* category ^slicing.discriminator.path = "$this"
 * category ^slicing.rules = #open
 * category contains
     first 1..* 

--- a/input/fsh/profiles/JP_Observation_Electrocardiogram.fsh
+++ b/input/fsh/profiles/JP_Observation_Electrocardiogram.fsh
@@ -64,8 +64,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 //* interpretation from JP_ObservationElectrocardiogramInterpretationCode_VS (extensible)
 * interpretation ^comment = "心電図所見・解釈について記載する。心電図所見は測定された結果と1対1で対応するものではなく、総合的に判断されるものである。したがって所見や解釈はこのエレメントに列記することとした。所見については、ミネソタコードを元に学会や検査機器ベンダーが用語集を作成している。必要に応じてそれらのコードを仕様することを推奨する。"
 * interpretation ^requirements = "心電図所見についてのコード集を別途提示する。"
-* interpretation ^slicing.discriminator.type = #value
-* interpretation ^slicing.discriminator.path = "coding.system"
+* interpretation ^slicing.discriminator.type = #pattern
+* interpretation ^slicing.discriminator.path = "$this"
 * interpretation ^slicing.rules = #open
 * interpretation ^slicing.ordered = false
 * interpretation contains
@@ -115,8 +115,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 //* component.interpretation from JP_ObservationElectrocardiogramInterpretationCode_VS (extensible)
 * component.interpretation ^definition = "心電図検査で測定された結果値に対する所見・解釈"
 * component.interpretation ^comment = "心電図検査の測定結果と解釈は必ずしも1対1で対応しないが、PR間隔の測定値にPR間隔延長などの固有の所見をつけてもよい"
-* component.interpretation ^slicing.discriminator.type = #value
-* component.interpretation ^slicing.discriminator.path = "coding.system"
+* component.interpretation ^slicing.discriminator.type = #pattern
+* component.interpretation ^slicing.discriminator.path = "$this"
 * component.interpretation ^slicing.rules = #open
 * component.interpretation ^slicing.ordered = false
 * component.interpretation contains


### PR DESCRIPTION
## 概要

Issue #953 に対応。`CodeableConcept` 型の要素（`category` / `interpretation`）を `discriminator.type = #value` / `path = "coding.system"` で slice していたため、**1つの CodeableConcept が複数 coding を持つ場合に discriminator が一意値を返せず、slice 振り分けが曖昧化**する R4 slicing ベストプラクティス違反を修正します。

## 修正方針

対象 slice はいずれも **`coding.system` のみを固定する部分パターン**（`code` は ValueSet 拘束のみで完全固定ではない）です。このため：

- 完全値一致を要求する `#value`（DiagnosticReport 系のように system+code を完全固定する場合に適切）ではなく、
- **`#pattern` + `$this`**（CodeableConcept 全体に対する部分パターンマッチ＝US Core Observation 流）

を採用します。これにより discriminator は CodeableConcept 全体を評価するため、`coding.system` が複数値になっても曖昧化しません。

## 変更内容

| ファイル | 要素 | 変更 |
|---|---|---|
| `JP_Observation_Common.fsh` | `category` | `#value`/`coding.system` → `#pattern`/`$this` |
| `JP_Observation_Electrocardiogram.fsh` | `interpretation` | 同上 |
| `JP_Observation_Electrocardiogram.fsh` | `component.interpretation` | 同上 |

slice 本体（`category[first].coding.system = … (exactly)` 等）は変更していません。discriminator の型・パスのみの修正です。

## 対象外（誤検知の補足）

Issue が同種として挙げた `JP_Observation_DentalOral_eCS.fsh:95-97` は、`…value[x].coding`（**Coding 配列**）を `system` で slice する**正しいパターン**です（各 Coding の `system` は単一値）。本件の問題には該当しないため変更していません。

## 検証

- `sushi .` → **0 Errors / 0 Warnings**（294 リソース出力）。
- 生成された StructureDefinition で 3要素すべての discriminator が `[{"type":"pattern","path":"$this"}]` になっていることを確認。
- 完全な slicing 検証（実インスタンスとの突合）は CI の IG Publisher で実施されます。

## 留意点

- 本 PR は `Refs #953`（自動クローズなし）。マージ後に Issue クローズ可否をご判断ください。
- 既存の例示インスタンスは slice 振り分けがより堅牢になるだけで、振り分け結果は変わりません（破壊的変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
