### PR TITLE
fix: 全 SearchParameter に multipleOr/multipleAnd を明示 (#1067)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -94,6 +94,10 @@ Sync Impact Report
   `jp-org-dept-identifier-local-system`）。
   各インバリアントには重大度（error/warning）、人間可読な説明、
   FHIRPath 式を含めなければならない
+- **SearchParameter**: `multipleOr` / `multipleAnd` を明示しなければならない。
+  サーバーが当該検索パラメータで OR/AND 結合をサポートするか否かを
+  曖昧にしないため、全 SearchParameter で両要素を指定し、
+  `capabilitystatement-expectation` 拡張により期待度を示す（既定は `#MAY`）。
 
 ### V. リソース組織化 (Resource Organization)
 

--- a/input/fsh/searchparameters/JP_MedicationRequest_SP.fsh
+++ b/input/fsh/searchparameters/JP_MedicationRequest_SP.fsh
@@ -12,6 +12,12 @@ Usage: #definition
 * expression = "MedicationRequest.dosageInstruction.extension('http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationDosage_PeriodOfUse').value.ofType(Period).start"
 * xpath = "f:MedicationRequest/f:dosageInstruction/f:extension[@url='http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_MedicationDosage_PeriodOfUse']/f:valuePeriod/f:start"
 * xpathUsage = #normal
+* multipleOr = true
+* multipleOr.extension.url = $capabilityStatement-expectation
+* multipleOr.extension.valueCode = #MAY
+* multipleAnd = true
+* multipleAnd.extension.url = $capabilityStatement-expectation
+* multipleAnd.extension.valueCode = #MAY
 * comparator[0] = #eq
 * comparator[+] = #ne
 * comparator[+] = #gt

--- a/input/fsh/searchparameters/JP_Patient_SP.fsh
+++ b/input/fsh/searchparameters/JP_Patient_SP.fsh
@@ -12,3 +12,9 @@ Usage: #definition
 * expression = "Patient.name.where(extension('http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation').value.ofType(code)='SYL' and use='usual').text"
 * xpath = "f:Patient/f:name[f:extension/@url='http://hl7.org/fhir/StructureDefinition/iso21090-EN-representation' and f:extension/f:valueCode/@value='SYL' and f:use/@value='usual']/f:text"
 * xpathUsage = #phonetic
+* multipleOr = true
+* multipleOr.extension.url = $capabilityStatement-expectation
+* multipleOr.extension.valueCode = #MAY
+* multipleAnd = true
+* multipleAnd.extension.url = $capabilityStatement-expectation
+* multipleAnd.extension.valueCode = #MAY


### PR DESCRIPTION
## 概要

Issue #1067 に対応。SearchParameter の `multipleOr` / `multipleAnd` 指定が IG 内で不統一（`JP_Organization_SP` / `JP_Coverage_SP` は明示、他は未指定）だった問題を、**「明示する方針」で統一**します。

## 修正方針

既存の明示済み SP（`JP_Organization_SP` / `JP_Coverage_SP`）の流儀に完全に揃えます。

```fsh
* multipleOr = true
* multipleOr.extension.url = $capabilityStatement-expectation
* multipleOr.extension.valueCode = #MAY
* multipleAnd = true
* multipleAnd.extension.url = $capabilityStatement-expectation
* multipleAnd.extension.valueCode = #MAY
```

両要素を `true` とし、`capabilitystatement-expectation` 拡張で期待度を `#MAY`（サーバーは OR/AND 結合を **MAY** サポート）と明示します。

## 変更内容

| ファイル | 対象 SearchParameter | 変更 |
|---|---|---|
| `JP_MedicationRequest_SP.fsh` | `JP_MedicationRequest_Start_SP` | multipleOr/multipleAnd 追加 |
| `JP_Patient_SP.fsh` | `JP_Patient_KanaSort_SP` | multipleOr/multipleAnd 追加 |
| `.specify/memory/constitution.md` | FSH 記述規則 (Section IV) | 方針を明文化 |

- 要素は FHIR SearchParameter の定義順に従い `xpathUsage` の直後（`comparator` の前）に配置。
- constitution.md には「全 SearchParameter で multipleOr/multipleAnd を明示し、`capabilitystatement-expectation` 拡張で期待度（既定 `#MAY`）を示す」と追記（Issue 修正案 2 に対応）。

## 検証

- IG 内の全 SP ファイル（4件）で、SearchParameter 定義数と multipleOr/multipleAnd 指定数が **1:1 で一致**することを確認（不統一の解消）。
- `sushi .` → **0 Errors / 0 Warnings**。
- 生成された `SearchParameter-jp-medicationrequest-start-sp.json` / `SearchParameter-jp-patient-kanasort-sp.json` に `multipleOr` / `multipleAnd`（`true`）と `capabilitystatement-expectation` = `MAY` 拡張が反映されることを確認。

## 留意点

- 本 PR は `Refs #1067`（自動クローズなし）。マージ後に Issue クローズ可否をご判断ください。
- 値は既存パターンに合わせ一律 `true` + `#MAY` としています。検索パラメータ個別に OR/AND の可否が異なる場合は、別途 expectation の見直しが可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
