### PR TITLE
docs: JP_Common_Department_Extension の context=Resource 維持理由を明記 (#1068)

### DIFF
--- a/input/fsh/profiles/JP_Common_Department_Extension.fsh
+++ b/input/fsh/profiles/JP_Common_Department_Extension.fsh
@@ -16,7 +16,9 @@ Description: "診療科情報を格納するための汎用的な拡張。様々
 1. valueCodeableConcept: SS-MIX2診療科コードなどのコード化された診療科情報
 2. valueReference: JP_Organization_Departmentプロファイルを使用した診療科組織への参照
 
-用途に応じて適切な表現方法を選択すること。診療科名称の統一が困難な場合は、CodeableConceptのtext要素を使用してテキストベースで診療科名を記録することも可能。"""
+用途に応じて適切な表現方法を選択すること。診療科名称の統一が困難な場合は、CodeableConceptのtext要素を使用してテキストベースで診療科名を記録することも可能。
+
+【適用コンテキストについて】本拡張の適用コンテキスト（^context）は意図的に `Resource`（全リソース）を指定し、広い範囲での参照を前提としている。これは、日本の医療制度上、診療科という項目の必要性が高く、診療・検査・処方・予約・実施組織など多様なリソースが診療科情報を保持しうること、また多くの医療情報システムのデータベーステーブルに診療科コードが項目として記載されていることによる。適用先リソース型を限定列挙すると将来の利用箇所を制約しかねないため、汎用拡張として全リソースで利用可能とすることを優先している。なお、コンテキストが広いことにより IPS validator 等で「コンテキストが広すぎる」旨の警告（情報レベル）が出る場合があるが、上記の設計意図に基づく許容事項である。"""
 
 * url = "http://jpfhir.jp/fhir/core/Extension/StructureDefinition/JP_Common_Department" (exactly)
 * value[x] only CodeableConcept or Reference(JP_Organization_Department)


### PR DESCRIPTION
## 概要

Issue #1068 に対応。`JP_Common_Department_Extension` の適用コンテキスト `^context.expression = "Resource"`（全リソース＝最も広い指定）について、**広い範囲での参照を前提とする方針を採用**し、その理由を `^comment` に明記します（Issue 修正案 **2**）。

`Resource` コンテキスト自体は変更していません（限定列挙はしない）。

## 方針と理由

日本の医療制度上、**診療科という項目の必要性が高い**こと、具体的には:

- 診療・検査・処方・予約・実施組織など**多様なリソースが診療科情報を保持しうる**。
- **多くの医療情報システムのデータベーステーブルに診療科コードが項目として記載されている**。

これらの実態から、適用先リソース型を限定列挙すると将来の利用箇所を制約しかねないため、**汎用拡張として全リソースで利用可能とすること**を優先します。

## 変更内容

`input/fsh/profiles/JP_Common_Department_Extension.fsh` の root 要素 `^comment` に「【適用コンテキストについて】」として上記の設計意図を追記。あわせて、IPS validator 等で「コンテキストが広すぎる」旨の警告（情報レベル）が出る場合があるが設計意図に基づく許容事項である旨も記録。

```fsh
* ^context[0].type = #element
* ^context[=].expression = "Resource"   // ← 変更なし（維持）
...
* . ^comment = """... （既存の説明）...

【適用コンテキストについて】本拡張の適用コンテキスト（^context）は意図的に `Resource`（全リソース）を指定し、広い範囲での参照を前提としている。…（理由）…"""
```

## 検証

- `sushi .` → **0 Errors / 0 Warnings**。
- 生成 `StructureDefinition-jp-common-department.json` で `context` が `[{type: element, expression: Resource}]` のまま維持され、`comment` に理由が反映されることを確認。

## 留意点

- 本 PR は `Refs #1068`（自動クローズなし）。マージ後に Issue クローズ可否をご判断ください。
- validator 警告を明示的に抑制したい場合は、別途 `input/ignoreWarnings.txt` への登録も可能です（本 PR では設計意図の文書化に留めています）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
