### PR TITLE
fix: category/interpretation の slicing discriminator を coding.system に戻す (#1088, revert #953)

### DIFF
--- a/input/fsh/profiles/JP_Observation_Common.fsh
+++ b/input/fsh/profiles/JP_Observation_Common.fsh
@@ -22,8 +22,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 * status ^comment = "このリソースは現在有効でないというマークをするコードを含んでいるため、この要素はモディファイアー（修飾的要素）として位置づけられている。"
 * insert SetDefinition(category, 行われた検査の一般的なタイプの分類。JP Core Observation Common Profileの【詳細説明】を参照のこと。)
 //* category from $JP_SimpleObservationCategory_VS (preferred)
-* category ^slicing.discriminator.type = #pattern
-* category ^slicing.discriminator.path = "$this"
+* category ^slicing.discriminator.type = #value
+* category ^slicing.discriminator.path = "coding.system"
 * category ^slicing.rules = #open
 * category contains
     first 1..* 

--- a/input/fsh/profiles/JP_Observation_Electrocardiogram.fsh
+++ b/input/fsh/profiles/JP_Observation_Electrocardiogram.fsh
@@ -64,8 +64,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 //* interpretation from JP_ObservationElectrocardiogramInterpretationCode_VS (extensible)
 * interpretation ^comment = "心電図所見・解釈について記載する。心電図所見は測定された結果と1対1で対応するものではなく、総合的に判断されるものである。したがって所見や解釈はこのエレメントに列記することとした。所見については、ミネソタコードを元に学会や検査機器ベンダーが用語集を作成している。必要に応じてそれらのコードを仕様することを推奨する。"
 * interpretation ^requirements = "心電図所見についてのコード集を別途提示する。"
-* interpretation ^slicing.discriminator.type = #pattern
-* interpretation ^slicing.discriminator.path = "$this"
+* interpretation ^slicing.discriminator.type = #value
+* interpretation ^slicing.discriminator.path = "coding.system"
 * interpretation ^slicing.rules = #open
 * interpretation ^slicing.ordered = false
 * interpretation contains
@@ -115,8 +115,8 @@ Description: "このプロファイルはObservationリソースに対して、�
 //* component.interpretation from JP_ObservationElectrocardiogramInterpretationCode_VS (extensible)
 * component.interpretation ^definition = "心電図検査で測定された結果値に対する所見・解釈"
 * component.interpretation ^comment = "心電図検査の測定結果と解釈は必ずしも1対1で対応しないが、PR間隔の測定値にPR間隔延長などの固有の所見をつけてもよい"
-* component.interpretation ^slicing.discriminator.type = #pattern
-* component.interpretation ^slicing.discriminator.path = "$this"
+* component.interpretation ^slicing.discriminator.type = #value
+* component.interpretation ^slicing.discriminator.path = "coding.system"
 * component.interpretation ^slicing.rules = #open
 * component.interpretation ^slicing.ordered = false
 * component.interpretation contains


### PR DESCRIPTION
## 概要

Issue #1088 に対応。#953（PR #1084）による slicing discriminator の変更が **子プロファイルのスライシングを破壊する回帰**を生んだため、**`#value` / `coding.system` に差し戻す**（方針: 元に戻す）。

## 背景（回帰の原因）

#953 で以下を `#value` / `coding.system` → `#pattern` / `$this` に変更した:

- `JP_Observation_Common.category`
- `JP_Observation_Electrocardiogram.interpretation` / `component.interpretation`

しかし、これを継承する子プロファイルの category スライスは判別値を **`coding.system` / `coding.code`（子要素）に固定**しており、**`$this`（CodeableConcept 自身）に `patternCodeableConcept` を持たない**。`#pattern` / `$this` discriminator はスライス要素自身にパターン/固定値/バインディングを要求するため、IG Publisher がスライシングを評価できずエラーになっていた。

検証レポート（IG Publisher v2.0.25）での影響:
- `DiagnosticReport-jp-diagnosticreport-microbiology-example-1`: **errors=120**
- `$this` 関連スライシングエラー **366 件**＋ `hasMember` / contained の profile マッチ失敗の連鎖
- 歯科系 example（`JP_Observation_DentalOral_*`）も同型で多数

## 修正方針

各スライス（first/second/third）は **互いに異なる `coding.system` を固定**する設計のため、`coding.system` discriminator で一意に判別できる。#953 が懸念した「1 つの CodeableConcept に複数 coding がある場合の曖昧化」は JP Core の実際のスライス設計（1 スライス = 1 system）では発生しない。よって `coding.system` に戻すのが妥当。

## 変更内容

| ファイル | 要素 | 変更 |
|---|---|---|
| `JP_Observation_Common.fsh` | `category` | `#pattern`/`$this` → `#value`/`coding.system` |
| `JP_Observation_Electrocardiogram.fsh` | `interpretation` | 同上 |
| `JP_Observation_Electrocardiogram.fsh` | `component.interpretation` | 同上 |

→ #953 の変更（3 箇所）の正確な逆変換。子プロファイル（Microbiology / Dental）側は変更不要。

## 検証

- `sushi .` → **0 Errors / 0 Warnings**。
- 生成 SD で 3 要素とも discriminator が `[{"type":"value","path":"coding.system"}]` に復帰することを確認。
- 本変更で `$this` 起因のスライシングエラー（366 件＋連鎖）が解消される見込み（最終確認は CI の IG Publisher 検証にて）。

## 留意点

- 本 PR は `Refs #1088`（自動クローズなし）。**Issue #1088 のその他の指摘（未知 CodeSystem OID、example 未リンク 等）は別途対応**との方針のため、本 PR ではスライシング回帰の解消のみを行う。
- 再発防止として、slicing 変更を含む PR はマージ前に IG Publisher 検証を行うことを推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
