### PR TITLE
[Low] aliases-jpcore.fsh: コメントアウトされた未使用 alias 定義を整理・削除 (L1/#1011)

### DIFF
--- a/input/fsh/aliases-jpcore.fsh
+++ b/input/fsh/aliases-jpcore.fsh
@@ -231,10 +231,8 @@ Alias: $JP_ProcedureReason_CS = http://jpfhir.jp/fhir/core/CodeSystem/JP_Undefin
 Alias: $JP_SimpleObservationCategory_CS = http://jpfhir.jp/fhir/core/CodeSystem/JP_SimpleObservationCategory_CS
 Alias: $JP_Undefined_CS = http://jpfhir.jp/fhir/core/CodeSystem/JP_Undefined_CS
 
-// Clinsでは定義されているが、JP Coreでは未定義
-// Alias: $JP_BodySite_MEDIS_Concept_CS = http://medis.or.jp/CodeSystem/master-disease-modExCode   //MEDIS病名交換用修飾コード //urn:oid:1.2.392.200119.4.201.5
-// Alias: $JP_BodySite_MEDIS_ManagementID_CS = http://medis.or.jp/CodeSystem/master-disease-modKeyNumber   //MEDIS病名管理修飾コード    //urn:oid:1.2.392.200119.4.201.2
-// Alias: $JP_BodySite_Disease_Claim_CS = http://jpfhir.jp/fhir/core/mhlw/CodeSystem/masterZ-disease-modifier //  支払基金	修飾語コード 
+// 病名修飾コード（MEDIS病名交換用/管理修飾コード、支払基金修飾語コード）の CodeSystem alias は
+// Clins では定義されているが JP Core では未定義のため、ここでは定義しない（将来採用時に追加）。
 
 
 // ValueSet
@@ -359,11 +357,8 @@ Alias: $JP_ReasonCodesJed_VS = http://jpfhir.jp/fhir/core/ValueSet/JP_ReasonCode
 Alias: $JP_SimpleObservationCategory_VS = http://jpfhir.jp/fhir/core/ValueSet/JP_SimpleObservationCategory_VS
 Alias: $JP_Undefined_VS = http://jpfhir.jp/fhir/core/ValueSet/JP_Undefined_VS
 
-// Alias: $JP_BodySite_MEDIS_Concept_VS = http://medis.or.jp/ValueSet/master-disease-modExCode
-
-// Alias: $JP_BodySite_MEDIS_ManagementID_VS = http://medis.or.jp/ValueSet/master-disease-modKeyNumber
-// Alias: $JP_BodySite_Disease_Claim_VS = http://jpfhir.jp/fhir/core/mhlw/ValueSet/masterZ-disease-modifier //  支払基金	修飾語コード
-// Alias: $JP_Modifier_Disease_Claim_VS = http://jpfhir.jp/fhir/core/mhlw/ValueSet/masterZ-disease-modifier //  支払基金	修飾語コード
+// 病名修飾コード（MEDIS病名交換用/管理修飾コード、支払基金修飾語コード）の ValueSet alias は
+// Clins では定義されているが JP Core では未定義のため、ここでは定義しない（将来採用時に追加）。
 
 //system値
 Alias: $JP_IdSystem_InsurerNumber = http://jpfhir.jp/fhir/core/mhlw/IdSystem/InsurerNumber  //urn:oid:1.2.392.100495.20.3.61


### PR DESCRIPTION
## 概要

#1033 に対応。`input/fsh/aliases-jpcore.fsh` に残存していた、コメントアウト済みの未使用 alias 定義を整理しました。

## 変更内容

- **CodeSystem セクション**（旧 234-237 行）: コメントアウトされた 3 件の alias 定義を削除し、設計判断を 1 行コメントに集約。
  - `$JP_BodySite_MEDIS_Concept_CS` / `$JP_BodySite_MEDIS_ManagementID_CS` / `$JP_BodySite_Disease_Claim_CS`
- **ValueSet セクション**（旧 362-366 行）: コメントアウトされた 4 件の alias 定義を削除し、設計判断を 1 行コメントに集約。
  - `$JP_BodySite_MEDIS_Concept_VS` / `$JP_BodySite_MEDIS_ManagementID_VS` / `$JP_BodySite_Disease_Claim_VS` / `$JP_Modifier_Disease_Claim_VS`（重複定義）

「Clins では定義されているが JP Core では未定義」という設計意図は、個々のコメント行ではなくセクションごとの 1 行コメントに集約して残しています。削除した定義は Git 履歴に残ります。

## 補足（重複定義について）

Issue で指摘された重複の調査結果:

- コメントアウトされていた `// Alias: $JP_Modifier_Disease_Claim_VS` は、**有効な定義**（`aliases-jpcore.fsh:316`）の重複でした。
- 有効な `$JP_Modifier_Disease_Claim_CS`（198 行目）/ `$JP_Modifier_Disease_Claim_VS`（316 行目）は `JP_Condition_Diagnosis.fsh` 等から参照されているため、**そのまま維持**しています。
- したがって今回の削除はコメント行（死蔵コード）のみで、実体への影響はありません。

## 深刻度

Low

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)