### PR TITLE
fix(docs): FHIRContentsにWorkflow/CS/SPグループへの導線を追加 (#972)

### DIFF
--- a/input/pagecontent/group-fhircontents.md
+++ b/input/pagecontent/group-fhircontents.md
@@ -2,3 +2,6 @@
 * [Medicationグループ](group-medication.html)
 * [Diagnosticグループ](group-diagnostic.html)
 * [Clinicalグループ](group-clinical.html)
+* [Workflowグループ](group-workflow.html)
+* [CapabilityStatementグループ](group-capabilityStatement.html)
+* [SearchParameterグループ](group-searchParameter.html)


### PR DESCRIPTION
## 概要

`input/pagecontent/group-fhircontents.md` が Administration / Medication / Diagnostic / Clinical の **4リンクのみ** で、Workflow / CapabilityStatement / SearchParameter グループページへのナビゲーション導線が欠落していた問題を修正します。

Closes #972

## 変更内容

`group-fhircontents.md` に以下3グループへのリンクを追加:

- `[Workflowグループ](group-workflow.html)`
- `[CapabilityStatementグループ](group-capabilityStatement.html)`
- `[SearchParameterグループ](group-searchParameter.html)`

## 確認事項

- リンク先 3 ページ（`group-workflow.md` / `group-capabilityStatement.md` / `group-searchParameter.md`）はいずれも既存ファイルとして存在することを確認済み
- 既存4行と同じ `〜グループ` 表記・LF改行を踏襲
- ドキュメント（ナビゲーションリスト）のみの変更で、FSH / リソース定義への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)