### PR TITLE
fix(script): resourcelist_creator.rb の用語パッケージパスを #1.4.0 に修正 (#979)

### DIFF
--- a/script/resourcelist_creator.rb
+++ b/script/resourcelist_creator.rb
@@ -53,7 +53,7 @@ end
 # -------------------------------------------------------
 work = "./temp/scriptwork/"
 
-target1 = Dir.home.to_s + "/.fhir/packages/jpfhir-terminology.r4#1.3.0/package"
+target1 = Dir.home.to_s + "/.fhir/packages/jpfhir-terminology#1.4.0/package"
 file1 = "resource_info_terminlogy.csv"
 
 target2 = "./fsh-generated/resources/"


### PR DESCRIPTION
## 概要

`script/resourcelist_creator.rb:56` が用語パッケージのパスを `jpfhir-terminology.r4#1.3.0` とハードコードしており、**パッケージ名（`.r4` 接尾）と版数（1.3.0）の二重ミス**によりスクリプト実行時にパッケージ未検出エラーになる問題を修正します。

Closes #979

## 変更内容

```diff
-target1 = Dir.home.to_s + "/.fhir/packages/jpfhir-terminology.r4#1.3.0/package"
+target1 = Dir.home.to_s + "/.fhir/packages/jpfhir-terminology#1.4.0/package"
```

## 根拠（実体との整合）

| 参照元 | パッケージ名 / 版数 |
|--------|----------------------|
| `_updateTx.sh:45` | `jpfhir-terminology#1.4.0`（`.r4` 接尾なし） |
| `sushi-config.yaml` dependencies | `jpfhir-terminology` version `1.4.0` |
| 実際のインストール先 | `~/.fhir/packages/jpfhir-terminology#1.4.0` |

修正後のパス `~/.fhir/packages/jpfhir-terminology#1.4.0/package` が実在することを確認済み。

## 確認事項

- `ruby -c script/resourcelist_creator.rb` → Syntax OK
- スクリプトのみの変更で FSH / リソース定義への影響なし

## 補足（今回は対象外）

Issue 記載の「長期的には sushi-config.yaml の dependencies を読み込んで動的にパス構築」については、当環境の Ruby (Psych) が sushi-config.yaml 内の `date` 値を安全ロードでブロックするため `permitted_classes` 等の追加対応が必要で、Ruby バージョン依存のリスクがあります。本PRでは Issue の具体的な修正案（版数・パッケージ名の修正）に限定し、動的化は別途検討とします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)