### PR TITLE
[Med] バージョン情報を sushi-config.yaml に一元化 (#980)

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -46,11 +46,28 @@ jobs:
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 
+    # sushi-config.yaml を single source of truth とし、ビルド用の version / releaseLabel を確定させる
+    - name: apply the version of sushi-config.yaml
+      run: |
+        sed -i 's/releaseLabel: release/releaseLabel: ci-build/g' sushi-config.yaml
+        sed -i 's/version: 1.2.0-temp/version: ${{ env.release_version }}/g' sushi-config.yaml
+
+    # 確定した version / releaseLabel を sushi-config.yaml から読み取り、_index.yml に注入する
+    - name: Read version and releaseLabel from sushi-config.yaml
+      id: sushi_meta
+      run: |
+        version=$(grep -E '^version:' sushi-config.yaml | head -1 | sed -E 's/^version:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+        release_type=$(grep -E '^releaseLabel:' sushi-config.yaml | head -1 | sed -E 's/^releaseLabel:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "release_type=$release_type" >> $GITHUB_OUTPUT
+
     - uses: bluwy/substitute-string-action@v1
       id: substitute_index
       with:
         _input-file: input/landing_page/_index.yml
         _format-key: '%%key%%'
+        version: ${{ steps.sushi_meta.outputs.version }}
+        release_type: ${{ steps.sushi_meta.outputs.release_type }}
         group: ${{ steps.extract_branch.outputs.branch_group }}
         branch: ${{ steps.extract_branch.outputs.branch }}
         date: ${{ steps.extract_date.outputs.date }}
@@ -112,11 +129,6 @@ jobs:
         mkdir -p packages/$JPTerminologyCOREdir
         mv /home/runner/.fhir/work/package /home/runner/.fhir/packages/$JPTerminologyCOREdir
          
-    - name: apply the version of sushi-config.yaml
-      run: |
-        sed -i 's/releaseLabel: release/releaseLabel: ci-build/g' sushi-config.yaml
-        sed -i 's/version: 1.2.0-temp/version: ${{ env.release_version }}/g' sushi-config.yaml
-        
     - name: Run IG Publisher
       run: | 
         mkdir input-cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,11 +42,27 @@ jobs:
         echo "encoded_pullrequest_title=$title_temp" >> $GITHUB_ENV
       id: extract_date
 
+    # sushi-config.yaml を single source of truth とし、ビルド用の version / releaseLabel を確定させる
+    - name: apply the version of sushi-config.yaml
+      run: |
+        sed -i 's/version: 1.2.0-temp/version: ${{ env.release_version }}/g' sushi-config.yaml
+
+    # 確定した version / releaseLabel を sushi-config.yaml から読み取り、_index.yml に注入する
+    - name: Read version and releaseLabel from sushi-config.yaml
+      id: sushi_meta
+      run: |
+        version=$(grep -E '^version:' sushi-config.yaml | head -1 | sed -E 's/^version:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+        release_type=$(grep -E '^releaseLabel:' sushi-config.yaml | head -1 | sed -E 's/^releaseLabel:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "release_type=$release_type" >> $GITHUB_OUTPUT
+
     - uses: bluwy/substitute-string-action@v1
       id: substitute_index
       with:
         _input-file: input/landing_page/_index.yml
         _format-key: '%%key%%'
+        version: ${{ steps.sushi_meta.outputs.version }}
+        release_type: ${{ steps.sushi_meta.outputs.release_type }}
         group: ${{ steps.extract_branch.outputs.branch_group }}
         branch: ${{ steps.extract_branch.outputs.branch }}
         date: ${{ steps.extract_date.outputs.date }}
@@ -108,10 +124,6 @@ jobs:
         mkdir -p packages/$JPTerminologyCOREdir
         mv /home/runner/.fhir/work/package /home/runner/.fhir/packages/$JPTerminologyCOREdir
 
-    - name: apply the version of sushi-config.yaml
-      run: |
-        sed -i 's/version: 1.2.0-temp/version: ${{ env.release_version }}/g' sushi-config.yaml
-        
     - name: Run IG Publisher
       run: | 
         mkdir input-cache

--- a/input/landing_page/_index.yml
+++ b/input/landing_page/_index.yml
@@ -1,10 +1,10 @@
 name: HL7-FHIR-JP-Core-R4
-version: 1.3.0
+version: %%version%%
 description: FHIR&reg Japanese Core Implementation Guide R4 by Japanese implementation research working group in Japan Association of Medical Informatics (JAMI)
 last_published: %%date%%
 group: %%group%%
 branch: %%branch%%
 actor: %%actor%%
-type: draft
+type: %%release_type%%
 pullrequest_url: %%pullrequest_url%%
 pullrequest_title: %%pullrequest_title%%


### PR DESCRIPTION
## 概要

#980 に対応。JP Core のバージョン情報が 3 系統（`_index.yml` / `sushi-config.yaml` / workflow env）に散在し、公開される landing page の表示値と実際のビルド値が乖離していた問題を解消します。

## 問題点（修正前）

| 箇所 | version | type / releaseLabel |
|------|---------|--------------------|
| `input/landing_page/_index.yml` | `1.3.0`（ハードコード） | `type: draft`（ハードコード） |
| `sushi-config.yaml` | `1.2.0-temp`（CI 置換用プレースホルダ） | `releaseLabel: release` |
| `.github/workflows/{main,develop}.yaml` | `release_version: 1.3.0-dev`（env、sed で sushi-config に注入） | develop は `releaseLabel: release → ci-build` に書換 |

`_index.yml` の `version`/`type` がハードコードのため、実際にビルド・公開されるバージョン（`1.3.0-dev`）と表示（`1.3.0` / `draft`）が一致せず、リリース毎に手作業更新と更新漏れのリスクがあった。

## 修正内容

`sushi-config.yaml`（CI で確定する version/releaseLabel）を landing page の唯一の供給元とし、`_index.yml` 側はプレースホルダ化して CI で注入する。

1. **`input/landing_page/_index.yml`**
   - `version: 1.3.0` → `version: %%version%%`
   - `type: draft` → `type: %%release_type%%`

2. **`.github/workflows/develop.yaml` / `main.yaml`**
   - 既存の「sushi-config.yaml への version/releaseLabel 適用（sed）」ステップを `_index.yml` 置換より**前**に移動。
   - 適用後の `sushi-config.yaml` から `version` / `releaseLabel` を読み取るステップ（`sushi_meta`）を追加。
   - `substitute-string-action` に `version` / `release_type` キーを追加し、`%%version%%` / `%%release_type%%` を注入。

これにより、公開される landing page の `version` / `type` が実際のビルド値と常に一致する。

## 注入される値（確認済み）

| ブランチ | version | release_type |
|---------|---------|--------------|
| develop | `1.3.0-dev`（= `env.release_version`） | `ci-build` |
| main | `1.3.0-dev`（= `env.release_version`） | `release` |

ローカルで実際の `sushi-config.yaml` に対し sed → grep/sed 抽出を実行し、上記の値が末尾コメント・空白を含まずクリーンに取得できることを確認しています。

## 補足

- バージョン番号の実体は引き続き各 workflow の `env.release_version` で管理します（ブランチ別に値を変えられる運用上の制御点のため）。`sushi-config.yaml` の `1.2.0-temp` は CI 置換用のセンチネルで、バージョン更新時の編集対象ではありません。
- 両 workflow の YAML 構文は検証済みです。
- IG Publisher による実ビルドは未実施です（CI 上でのみ実行されるフローのため）。

## 深刻度

Med

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)