### PR TITLE
[Low] resourcelist_creator.rb:57 出力ファイル名タイポ修正 (terminlogy→terminology) (#1044)

### DIFF
--- a/script/resourcelist_creator.rb
+++ b/script/resourcelist_creator.rb
@@ -54,7 +54,7 @@ end
 work = "./temp/scriptwork/"
 
 target1 = Dir.home.to_s + "/.fhir/packages/jpfhir-terminology#1.4.0/package"
-file1 = "resource_info_terminlogy.csv"
+file1 = "resource_info_terminology.csv"
 
 target2 = "./fsh-generated/resources/"
 file2 = "resource_info_jpcore.csv"


### PR DESCRIPTION
## 概要

Issue #1044 の対応。`script/resourcelist_creator.rb:57` の出力 CSV ファイル名の綴り誤りを修正。

```diff
-file1 = "resource_info_terminlogy.csv"
+file1 = "resource_info_terminology.csv"
```

## 確認事項

- リポジトリ全体を検索し、`resource_info_termin*` の参照は当該 1 箇所のみ（`./temp/scriptwork/` 配下の中間生成物として同スクリプト内で書き出されるだけ）で、外部の後続処理・consumer は存在しないことを確認。リネームによる副作用なし。
- `ruby -c` による構文チェック: Syntax OK。

## 関連メモ（Issue の「任意」項目について）

Issue で言及された 56 行目の用語パッケージパスのバージョンハードコードは、既に **#979 で `1.4.0` に修正済み**（`~/.fhir/packages/jpfhir-terminology#1.4.0/package`）であり、CI が取り込む `jpfhir-terminology#1.4.0` と一致しています。本 PR での追加対応は不要と判断しました。

## 親 Issue

#1011 （Round 4-5 Low まとめ）項目 L12

Closes #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)