### PR TITLE
fix(examples): 検体材料・検体検査レポートの例データを修正 (#940, #960, #1066)

### DIFF
--- a/input/fsh/examples/JP_DiagnosticReportLabResult_Example.fsh
+++ b/input/fsh/examples/JP_DiagnosticReportLabResult_Example.fsh
@@ -20,7 +20,6 @@ Usage: #example
 * presentedForm.language = #ja-JP
 * presentedForm.data = "JVBERi0xLjUNCiW1tbW1DQoxIDAgb2JqDQo8PC9UeXBlL0NhdGFsb2cvUGFnZXMgMiAwIFIvTGFuZyhqYS1KUCkgL1N0cnVjdFRyZWVSb290IDEzIDAgUi9NYXJrSW5mbzw8L01hcmtlZCB0cnVlPj4+Pg0KZW5kb2JqDQoyIDAgb2JqDQo8PC9UeXBlL1BhZ2VzL0NvdW50IDEvS2lkc1sgMyAwIFJdID4+DQplbmRvYmoNCjMgMCBvYmoN"
 * presentedForm.title = "検査結果PDFレポート"
-* effectiveDateTime = "2021-08-25T08:30:00+09:00"
 * result[0] = Reference(Observation/inner-observation-labresult-1)
 * result[+] = Reference(Observation/inner-observation-labresult-2)
 * result[+] = Reference(Observation/inner-observation-labresult-3)
@@ -55,7 +54,6 @@ Usage: #inline
 * referenceRange.low = 4.2 '10*6/uL' "10*6./L"
 * referenceRange.high = 6 '10*6/uL' "10*6./L"
 * effectiveDateTime = "2021-03-04T08:30:00+09:00"
-* effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * specimen = Reference(Specimen/jp-specimen-example-2)
 
 Instance: inner-observation-labresult-3
@@ -76,5 +74,4 @@ Usage: #inline
 * referenceRange.low.unit = "%"
 * referenceRange.high.value = 52
 * referenceRange.high.unit = "%"
-* effectiveDateTime = "2021-03-04T08:30:00+09:00"
 * specimen = Reference(Specimen/jp-specimen-example-2)

--- a/input/fsh/examples/JP_Specimen_Example.fsh
+++ b/input/fsh/examples/JP_Specimen_Example.fsh
@@ -34,8 +34,8 @@ Usage: #example
 * subject = Reference(Patient/jp-patient-example-1)
 * receivedTime = "2021-08-11T11:03:00+09:00"
 * container.identifier.value = "48736-15394-75467"
-* container.description = "採血菅"
-* container.type.text = "採血菅"
+* container.description = "採血管"
+* container.type.text = "採血管"
 * container.capacity.value = 20
 * container.capacity.unit = "mL"
 * container.specimenQuantity.value = 18
@@ -53,12 +53,12 @@ Usage: #example
 * accessionIdentifier.system = "http://example.org/abc-hospital/specimens/2011"
 * accessionIdentifier.value = "X352358"
 * status = #available
-* type = http://terminology.hl7.org/CodeSystem/v2-0487#BLD "Whole blood"
+* type = http://terminology.hl7.org/CodeSystem/v2-0487#SPT "Sputum"
 * subject = Reference(Patient/jp-patient-example-1)
 * receivedTime = "2021-08-11T11:03:00+09:00"
 * container.identifier.value = "48736-15394-75468"
-* container.description = "採血菅"
-* container.type.text = "採血菅"
+* container.description = "採痰容器"
+* container.type.text = "採痰容器"
 * container.capacity.value = 20
 * container.capacity.unit = "mL"
 * container.specimenQuantity.value = 3


### PR DESCRIPTION
## 修正内容

Issue #940 / #960 / #1066 の対応。検体材料および検体検査レポートの example データの誤りを修正した。3 件とも検体検査分科会の担当で、対象ファイルが重複するため 1 PR にまとめた。

### `input/fsh/examples/JP_Specimen_Example.fsh`

| 対象 | 修正前 | 修正後 | Issue |
| --- | --- | --- | --- |
| jp-specimen-example-3 `type` | `v2-0487#BLD "Whole blood"` | `v2-0487#SPT "Sputum"` | #940 |
| jp-specimen-example-3 `container.description` / `container.type.text` | 採血菅 | 採痰容器 | #940 |
| jp-specimen-example-2 `container.description` / `container.type.text` | 採血菅 | 採血管 | #1066 |

`jp-specimen-example-3` は Title / Description が「喀痰」であるにもかかわらず、`jp-specimen-example-2`（血液）からのコピー時の修正漏れで血液コードが残っていた。

### `input/fsh/examples/JP_DiagnosticReportLabResult_Example.fsh`

`effectiveDateTime` の重複代入を 3 組削除した（#960）。

| Instance | 削除した値 | 残した値 | 影響 |
| --- | --- | --- | --- |
| jp-diagnosticreport-labresult-example-1 | 2021-08-25 | 2021-03-04 | 生成 JSON が変化（値が異なる真の重複） |
| inner-observation-labresult-2 | 2021-03-04 | 2021-03-04 | 同値のため生成 JSON に影響なし |
| inner-observation-labresult-3 | 2021-03-04 | 2021-03-04 | 同値のため生成 JSON に影響なし |

残す値を 2021-03-04 とした根拠は、`issued` が `2021-03-04T11:45:33+09:00` であり、内包する Observation 3 件がいずれも `2021-03-04` を持つため。

## Merge依頼先

SWG2（検体検査分科会）

## レビュー観点

- **`SPT "Sputum"` の採用可否**: v2-0487 には `SPTC "Sputum - coughed"`、`SPTT "Sputum - tracheal aspirate"` 等のより特異的なコードも存在する。example として `SPT` で妥当か。
- **「採痰容器」という表記の妥当性**: 実務上の一般的な呼称と合っているか。
- **#960 で残す日付の判断**: 上記根拠で 2021-03-04 を採用した点。

## 関連ISSUE

- #940
- #960
- #1066

※ 本 PR では自動 Close キーワードを使用していない。マージ内容を確認のうえ、各 Issue を手動で Close する想定。

## 補足

### Issue 記載との差分

いずれも Issue の記載より対象が広かったため、実測に基づいて対応した。

- **#940**: Issue は 56 行・60 行の 2 箇所を指摘していたが、`container.type.text`（61 行）も同様に修正が必要だった。
- **#960**: Issue は 16 / 23 行の 1 組のみ指摘していたが、重複代入は計 3 組存在した。ただし値が異なる真のバグは 16 / 23 行のみで、残り 2 組は同値のため生成 JSON には影響しない。
- **#1066**: 該当 4 箇所すべてを確認。うち 60-61 行は #940 により「採痰容器」となるため、「採血管」への置換は 37-38 行の 2 箇所に適用した。リポジトリ全体を検索し、「採血菅」の残存がないことを確認済み。

### 検証

- `sushi`: **0 Errors / 0 Warnings**。リソース数 294（Instances 188）で、変更前後の増減なし。
- 生成 JSON の差分は意図した 5 箇所のみで、副作用なし。`jp-specimen-example-1` は無変更。
- `SPT` / `Sputum` が `hl7.terminology.r4#7.3.0` の CodeSystem v2-0487 の定義と完全一致することを確認。
